### PR TITLE
refactor: Update InfluxDB client configuration

### DIFF
--- a/internal/stats/influx.go
+++ b/internal/stats/influx.go
@@ -33,8 +33,8 @@ type AgentsStats struct {
 }
 
 func (s *System) AddAgentSuccess(companyId, agentId, environmentId string) {
-	client := influxdb2.NewClient(s.Config.Local.GetValue("INFLUX_HOSTNAME"), s.Config.Local.GetValue("INFLUX_TOKEN"))
-	writeClient := client.WriteAPI(s.Config.Local.GetValue("INFLUX_ORG"), s.Config.Local.GetValue("INFLUX_BUCKET"))
+	client := influxdb2.NewClient(s.Config.Influx.Host, s.Config.Influx.Token)
+	writeClient := client.WriteAPI(s.Config.Influx.Org, s.Config.Influx.Bucket)
 
 	if environmentId == "" {
 		environmentId = "dev"
@@ -58,8 +58,8 @@ func (s *System) AddAgentSuccess(companyId, agentId, environmentId string) {
 }
 
 func (s *System) AddAgentError(companyId, agentId, environmentId string) {
-	client := influxdb2.NewClient(s.Config.Local.GetValue("INFLUX_HOSTNAME"), s.Config.Local.GetValue("INFLUX_TOKEN"))
-	writeClient := client.WriteAPI(s.Config.Local.GetValue("INFLUX_ORG"), s.Config.Local.GetValue("INFLUX_BUCKET"))
+	client := influxdb2.NewClient(s.Config.Influx.Host, s.Config.Influx.Token)
+	writeClient := client.WriteAPI(s.Config.Influx.Org, s.Config.Influx.Bucket)
 
 	if environmentId == "" {
 		environmentId = "dev"


### PR DESCRIPTION
Refactored the code to use configuration values from s.Config.Influx
instead of s.Config.Local for InfluxDB client setup. This ensures
consistency and improves readability.