### PR TITLE
feat(service): add wildcard origin to allowed origins

### DIFF
--- a/cmd/orchestrator/service.go
+++ b/cmd/orchestrator/service.go
@@ -37,7 +37,7 @@ func (pc ProjectConfig) Build(cfg *ConfigBuilder.Config) error {
 }
 
 func main() {
-	logs.Infof("Starting %s version %s (build %s)", ServiceName, BuildVersion, BuildHash)
+	logs.Logf("Starting %s version %s (build %s)", ServiceName, BuildVersion, BuildHash)
 
 	genericVaultPath := "kv/data/flags-gg/orchestrator"
 	vh := vault_helper.NewVault("", "")

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22
 require (
 	github.com/Nerzal/gocloak/v13 v13.9.0 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
-	github.com/bugfixes/go-bugfixes v0.12.16 // indirect
+	github.com/bugfixes/go-bugfixes v0.12.17 // indirect
 	github.com/caarlos0/env/v8 v8.0.0 // indirect
 	github.com/cenkalti/backoff/v3 v3.2.2 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/bugfixes/go-bugfixes v0.12.15 h1:1VeamkeQ3ffbbZAThsO6rgPKqxcpJ6H/G9vD
 github.com/bugfixes/go-bugfixes v0.12.15/go.mod h1:pwmYqCeq10O1s9U/aC0KceICp8kmNf9Tw4Nt4yJXTtU=
 github.com/bugfixes/go-bugfixes v0.12.16 h1:D6NQyGnO6iGXbXjjX1udjlLdS6rAzZgW+gnwoj4xKgQ=
 github.com/bugfixes/go-bugfixes v0.12.16/go.mod h1:pwmYqCeq10O1s9U/aC0KceICp8kmNf9Tw4Nt4yJXTtU=
+github.com/bugfixes/go-bugfixes v0.12.17 h1:8RfRWqPcjMKr8wwuW4yBcZWyhtfSHk5GLeFQqxcAn7Q=
+github.com/bugfixes/go-bugfixes v0.12.17/go.mod h1:vEKkwVTY1VSCPyRu1esWOzExVHi8C/+MdjfbPco3N3w=
 github.com/caarlos0/env/v8 v8.0.0 h1:POhxHhSpuxrLMIdvTGARuZqR4Jjm8AYmoi/JKlcScs0=
 github.com/caarlos0/env/v8 v8.0.0/go.mod h1:7K4wMY9bH0esiXSSHlfHLX5xKGQMnkH5Fk4TDSSSzfo=
 github.com/cenkalti/backoff/v3 v3.2.2 h1:cfUAAO3yvKMYKPrvhDuHSwQnhZNk/RMHKdZqKTxfm6M=

--- a/internal/agent/http.go
+++ b/internal/agent/http.go
@@ -25,7 +25,7 @@ type System struct {
 	Context context.Context
 }
 
-func NewAgentSystem(cfg *ConfigBuilder.Config) *System {
+func NewSystem(cfg *ConfigBuilder.Config) *System {
 	return &System{
 		Config: cfg,
 	}
@@ -69,17 +69,17 @@ func (s *System) GetAgentsRequest(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func GetAgent(w http.ResponseWriter, r *http.Request) {
+func (s *System) GetAgent(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write([]byte(`{"agent": {}}`))
 	return
 }
 
-func UpdateAgent(w http.ResponseWriter, r *http.Request) {
+func (s *System) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write([]byte(`{"agent": {}}`))
 	return
 }
 
-func DeleteAgent(w http.ResponseWriter, r *http.Request) {
+func (s *System) DeleteAgent(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write([]byte(`{"agent": {}}`))
 	return
 }
@@ -90,30 +90,30 @@ func (s *System) CreateAgent(w http.ResponseWriter, r *http.Request) {
 	return
 }
 
-func GetSecretMenu(w http.ResponseWriter, r *http.Request) {
+func (s *System) GetSecretMenu(w http.ResponseWriter, r *http.Request) {
 
 }
 
-func CreateSecretMenu(w http.ResponseWriter, r *http.Request) {
+func (s *System) CreateSecretMenu(w http.ResponseWriter, r *http.Request) {
 
 }
 
-func UpdateSecretMenu(w http.ResponseWriter, r *http.Request) {
+func (s *System) UpdateSecretMenu(w http.ResponseWriter, r *http.Request) {
 
 }
 
-func GetAgentEnvironments(w http.ResponseWriter, r *http.Request) {
+func (s *System) GetAgentEnvironments(w http.ResponseWriter, r *http.Request) {
 
 }
 
-func CreateAgentEnvironment(w http.ResponseWriter, r *http.Request) {
+func (s *System) CreateAgentEnvironment(w http.ResponseWriter, r *http.Request) {
 
 }
 
-func UpdateAgentEnvironment(w http.ResponseWriter, r *http.Request) {
+func (s *System) UpdateAgentEnvironment(w http.ResponseWriter, r *http.Request) {
 
 }
 
-func DeleteAgentEnvironment(w http.ResponseWriter, r *http.Request) {
+func (s *System) DeleteAgentEnvironment(w http.ResponseWriter, r *http.Request) {
 
 }

--- a/internal/agent/postgres.go
+++ b/internal/agent/postgres.go
@@ -67,7 +67,7 @@ func (s *System) GetAgents(companyId string) ([]*Agent, error) {
 			return nil, s.Config.Bugfixes.Logger.Errorf("Failed to scan database rows: %v", err)
 		}
 
-		envs, err := s.GetAgentEnvironments(agent.AgentId)
+		envs, err := s.GetAgentEnvironmentsFromDB(agent.AgentId)
 		if err != nil {
 			return nil, s.Config.Bugfixes.Logger.Errorf("Failed to get agent environments: %v", err)
 		}
@@ -79,7 +79,7 @@ func (s *System) GetAgents(companyId string) ([]*Agent, error) {
 	return agents, nil
 }
 
-func (s *System) GetAgentEnvironments(agentId string) ([]*Environment, error) {
+func (s *System) GetAgentEnvironmentsFromDB(agentId string) ([]*Environment, error) {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
 		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)

--- a/internal/company/http.go
+++ b/internal/company/http.go
@@ -19,7 +19,7 @@ type Company struct {
 	ID   string `json:"id"`
 }
 
-func NewCompanySystem(cfg *ConfigBuilder.Config) *System {
+func NewSystem(cfg *ConfigBuilder.Config) *System {
 	return &System{
 		Config: cfg,
 	}

--- a/internal/flags/agent.go
+++ b/internal/flags/agent.go
@@ -1,12 +1,12 @@
 package flags
 
 import (
-  "errors"
-  "fmt"
-  "github.com/flags-gg/orchestrator/internal/stats"
-  "github.com/jackc/pgx/v5"
-  "math/rand"
-  "strings"
+	"errors"
+	"fmt"
+	"github.com/flags-gg/orchestrator/internal/stats"
+	"github.com/jackc/pgx/v5"
+	"math/rand"
+	"strings"
 )
 
 func (s *System) GetAgentFlags(companyId, agentId, environmentId string) (*Response, error) {
@@ -16,12 +16,12 @@ func (s *System) GetAgentFlags(companyId, agentId, environmentId string) (*Respo
 
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
-		stats.NewStatsSystem(s.Config).AddAgentError(companyId, agentId, environmentId)
+		stats.NewSystem(s.Config).AddAgentError(companyId, agentId, environmentId)
 		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
 		if err := client.Close(s.Context); err != nil {
-			stats.NewStatsSystem(s.Config).AddAgentError(companyId, agentId, environmentId)
+			stats.NewSystem(s.Config).AddAgentError(companyId, agentId, environmentId)
 			s.Config.Bugfixes.Logger.Fatalf("Failed to close database connection: %v", err)
 		}
 	}()
@@ -39,7 +39,7 @@ func (s *System) GetAgentFlags(companyId, agentId, environmentId string) (*Respo
 			return nil, nil
 		}
 
-		stats.NewStatsSystem(s.Config).AddAgentError(companyId, agentId, environmentId)
+		stats.NewSystem(s.Config).AddAgentError(companyId, agentId, environmentId)
 		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to query database: %v", err)
 	}
 
@@ -98,6 +98,6 @@ func (s *System) GetAgentFlags(companyId, agentId, environmentId string) (*Respo
 		res.SecretMenu = *sm
 	}
 
-	stats.NewStatsSystem(s.Config).AddAgentSuccess(companyId, agentId, environmentId)
+	stats.NewSystem(s.Config).AddAgentSuccess(companyId, agentId, environmentId)
 	return res, nil
 }

--- a/internal/flags/http.go
+++ b/internal/flags/http.go
@@ -1,13 +1,13 @@
 package flags
 
 import (
-  "context"
-  "encoding/json"
-  "github.com/flags-gg/orchestrator/internal/stats"
-  ConfigBuilder "github.com/keloran/go-config"
-  "net/http"
-  "strconv"
-  "time"
+	"context"
+	"encoding/json"
+	"github.com/flags-gg/orchestrator/internal/stats"
+	ConfigBuilder "github.com/keloran/go-config"
+	"net/http"
+	"strconv"
+	"time"
 )
 
 type SecretMenuStyle struct {
@@ -37,7 +37,7 @@ type System struct {
 	Context context.Context
 }
 
-func NewFlagsSystem(cfg *ConfigBuilder.Config) *System {
+func NewSystem(cfg *ConfigBuilder.Config) *System {
 	return &System{
 		Config: cfg,
 	}
@@ -98,20 +98,20 @@ func (s *System) GetFlags(w http.ResponseWriter, r *http.Request) {
 
 	if err := json.NewEncoder(w).Encode(responseObj); err != nil {
 		_, _ = w.Write([]byte(`{"error": "failed to encode response"}`))
-		stats.NewStatsSystem(s.Config).AddAgentError(r.Header.Get("x-company-id"), r.Header.Get("x-agent-id"), r.Header.Get("x-environment-id"))
+		stats.NewSystem(s.Config).AddAgentError(r.Header.Get("x-company-id"), r.Header.Get("x-agent-id"), r.Header.Get("x-environment-id"))
 		_ = s.Config.Bugfixes.Logger.Errorf("Failed to encode response: %v", err)
 	}
-	stats.NewStatsSystem(s.Config).AddAgentSuccess(r.Header.Get("x-company-id"), r.Header.Get("x-agent-id"), r.Header.Get("x-environment-id"))
+	stats.NewSystem(s.Config).AddAgentSuccess(r.Header.Get("x-company-id"), r.Header.Get("x-agent-id"), r.Header.Get("x-environment-id"))
 }
 
-func CreateFlags(w http.ResponseWriter, r *http.Request) {
-
-}
-
-func UpdateFlags(w http.ResponseWriter, r *http.Request) {
+func (s *System) CreateFlags(w http.ResponseWriter, r *http.Request) {
 
 }
 
-func DeleteFlags(w http.ResponseWriter, r *http.Request) {
+func (s *System) UpdateFlags(w http.ResponseWriter, r *http.Request) {
+
+}
+
+func (s *System) DeleteFlags(w http.ResponseWriter, r *http.Request) {
 
 }

--- a/internal/project/http.go
+++ b/internal/project/http.go
@@ -1,0 +1,92 @@
+package project
+
+import (
+	"context"
+	"encoding/json"
+	ConfigBuilder "github.com/keloran/go-config"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+type System struct {
+	Config  *ConfigBuilder.Config
+	Context context.Context
+}
+
+type Project struct {
+	Name      string `json:"name"`
+	ID        string `json:"id"`
+	CompanyID string `json:"company_id"`
+}
+
+func NewSystem(cfg *ConfigBuilder.Config) *System {
+	return &System{
+		Config: cfg,
+	}
+}
+
+func (s *System) GetProjects(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("x-flags-timestamp", strconv.FormatInt(time.Now().Unix(), 10))
+	s.Context = r.Context()
+
+	type Projects struct {
+		Projects []Project `json:"projects"`
+	}
+	project := Projects{}
+
+	if r.Header.Get("x-user-subject") == "" || r.Header.Get("x-user-access-token") == "" {
+		if err := json.NewEncoder(w).Encode(&project); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+		return
+	}
+}
+
+func (s *System) GetProject(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("x-flags-timestamp", strconv.FormatInt(time.Now().Unix(), 10))
+	s.Context = r.Context()
+
+	if r.Header.Get("x-user-subject") == "" || r.Header.Get("x-user-access-token") == "" {
+		if err := json.NewEncoder(w).Encode(&Project{}); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+		return
+	}
+}
+
+func (s *System) CreateProject(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("x-flags-timestamp", strconv.FormatInt(time.Now().Unix(), 10))
+	s.Context = r.Context()
+
+	if r.Header.Get("x-user-subject") == "" || r.Header.Get("x-user-access-token") == "" {
+		if err := json.NewEncoder(w).Encode(&Project{}); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+		return
+	}
+}
+
+func (s *System) UpdateProject(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("x-flags-timestamp", strconv.FormatInt(time.Now().Unix(), 10))
+	s.Context = r.Context()
+
+	if r.Header.Get("x-user-subject") == "" || r.Header.Get("x-user-access-token") == "" {
+		if err := json.NewEncoder(w).Encode(&Project{}); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+		return
+	}
+}
+
+func (s *System) DeleteProject(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("x-flags-timestamp", strconv.FormatInt(time.Now().Unix(), 10))
+	s.Context = r.Context()
+
+	if r.Header.Get("x-user-subject") == "" || r.Header.Get("x-user-access-token") == "" {
+		if err := json.NewEncoder(w).Encode(&Project{}); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+		return
+	}
+}

--- a/internal/project/postgres.go
+++ b/internal/project/postgres.go
@@ -1,0 +1,1 @@
+package project

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -16,7 +16,7 @@ func (s *Service) ValidateUser(w http.ResponseWriter, r *http.Request) bool {
 	}
 
 	if userSubject != "" && userAccessToken != "" {
-		validateUser := user.NewUserSystem(s.Config).ValidateUser(r.Context(), userSubject)
+		validateUser := user.NewSystem(s.Config).ValidateUser(r.Context(), userSubject)
 		if !validateUser {
 			w.WriteHeader(http.StatusUnauthorized)
 			return false
@@ -46,7 +46,7 @@ func (s *Service) ValidateAgent(w http.ResponseWriter, r *http.Request) bool {
 		// validate agent
 		if environmentId != "" {
 			// validate environment
-			v, err := agent.NewAgentSystem(s.Config).ValidateAgentWithEnvironment(r.Context(), agentId, companyId, environmentId)
+			v, err := agent.NewSystem(s.Config).ValidateAgentWithEnvironment(r.Context(), agentId, companyId, environmentId)
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				return false
@@ -54,7 +54,7 @@ func (s *Service) ValidateAgent(w http.ResponseWriter, r *http.Request) bool {
 			validAgent = v
 		}
 
-		v, err := agent.NewAgentSystem(s.Config).ValidateAgentWithoutEnvironment(r.Context(), agentId, companyId)
+		v, err := agent.NewSystem(s.Config).ValidateAgentWithoutEnvironment(r.Context(), agentId, companyId)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			return validAgent

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -76,7 +76,6 @@ func (s *Service) Auth(next http.Handler) http.Handler {
 
 		// Validate Agent
 		if valid := s.ValidateAgent(w, r); !valid {
-			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
 

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -37,6 +37,11 @@ func (s *Service) ValidateAgent(w http.ResponseWriter, r *http.Request) bool {
 		return true
 	}
 
+	// skip this check since this isn't the agent asking for flags
+	if r.URL.Path != "/flags" {
+		return true
+	}
+
 	if agentId != "" && companyId != "" {
 		// validate agent
 		if environmentId != "" {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -86,7 +86,7 @@ func (s *Service) startHTTP(errChan chan error) {
 	mw.AddMiddleware(mw.CORS)
 	mw.AddAllowedHeaders("x-agent-id", "x-company-id", "x-environment-id", "x-user-subject", "x-user-access-token")
 	mw.AddAllowedMethods(http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodOptions)
-	mw.AddAllowedOrigins("https://www.flags.gg", "https://flags.gg")
+	mw.AddAllowedOrigins("https://www.flags.gg", "https://flags.gg", "*")
 	if s.Config.Local.Development {
 		mw.AddAllowedOrigins("http://localhost:3000", "http://localhost:5173", "*")
 	}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/flags-gg/orchestrator/internal/agent"
 	"github.com/flags-gg/orchestrator/internal/company"
 	"github.com/flags-gg/orchestrator/internal/flags"
+	"github.com/flags-gg/orchestrator/internal/project"
 	"github.com/flags-gg/orchestrator/internal/stats"
 	"github.com/flags-gg/orchestrator/internal/user"
 )
@@ -39,39 +40,46 @@ func (s *Service) Start() error {
 func (s *Service) startHTTP(errChan chan error) {
 	mux := http.NewServeMux()
 	// Flags
-	mux.HandleFunc("GET /flags", flags.NewFlagsSystem(s.Config).GetFlags)
-	mux.HandleFunc("POST /flag", flags.CreateFlags)
-	mux.HandleFunc("PUT /flag/{flagId}", flags.UpdateFlags)
-	mux.HandleFunc("DELETE /flag/{flagId}", flags.DeleteFlags)
+	mux.HandleFunc("GET /flags", flags.NewSystem(s.Config).GetFlags)
+	mux.HandleFunc("POST /flag", flags.NewSystem(s.Config).CreateFlags)
+	mux.HandleFunc("PUT /flag/{flagId}", flags.NewSystem(s.Config).UpdateFlags)
+	mux.HandleFunc("DELETE /flag/{flagId}", flags.NewSystem(s.Config).DeleteFlags)
 
 	// Agents
-	mux.HandleFunc("GET /agents", agent.NewAgentSystem(s.Config).GetAgentsRequest)
-	mux.HandleFunc("POST /agent", agent.NewAgentSystem(s.Config).CreateAgent)
-	mux.HandleFunc("GET /agent/{agentId}", agent.GetAgent)
-	mux.HandleFunc("PUT /agent/{agentId}", agent.UpdateAgent)
-	mux.HandleFunc("DELETE /agent/{agentId}", agent.DeleteAgent)
-	mux.HandleFunc("GET /agent/{agentId}/environments", agent.GetAgentEnvironments)
-	mux.HandleFunc("POST /agent/{agentId}/environment", agent.CreateAgentEnvironment)
-	mux.HandleFunc("PUT /agent/{agentId}/environment/{environmentId}", agent.UpdateAgentEnvironment)
-	mux.HandleFunc("DELETE /agent/{agentId}/environment/{environmentId}", agent.DeleteAgentEnvironment)
+	mux.HandleFunc("GET /agents", agent.NewSystem(s.Config).GetAgentsRequest)
+	mux.HandleFunc("POST /agent", agent.NewSystem(s.Config).CreateAgent)
+	mux.HandleFunc("GET /agent/{agentId}", agent.NewSystem(s.Config).GetAgent)
+	mux.HandleFunc("PUT /agent/{agentId}", agent.NewSystem(s.Config).UpdateAgent)
+	mux.HandleFunc("DELETE /agent/{agentId}", agent.NewSystem(s.Config).DeleteAgent)
+	mux.HandleFunc("GET /agent/{agentId}/environments", agent.NewSystem(s.Config).GetAgentEnvironments)
+	mux.HandleFunc("POST /agent/{agentId}/environment", agent.NewSystem(s.Config).CreateAgentEnvironment)
+	mux.HandleFunc("PUT /agent/{agentId}/environment/{environmentId}", agent.NewSystem(s.Config).UpdateAgentEnvironment)
+	mux.HandleFunc("DELETE /agent/{agentId}/environment/{environmentId}", agent.NewSystem(s.Config).DeleteAgentEnvironment)
+
+	// Projects
+	mux.HandleFunc("GET /projects", project.NewSystem(s.Config).GetProjects)
+	mux.HandleFunc("POST /project", project.NewSystem(s.Config).CreateProject)
+	mux.HandleFunc("GET /project/{projectId}", project.NewSystem(s.Config).GetProject)
+	mux.HandleFunc("PUT /project/{projectId}", project.NewSystem(s.Config).UpdateProject)
+	mux.HandleFunc("DELETE /project/{projectId}", project.NewSystem(s.Config).DeleteProject)
 
 	// Secret Menu
-	mux.HandleFunc("GET /agent/{agentId}/secret-menu", agent.GetSecretMenu)
-	mux.HandleFunc("POST /agent/{agentId}/secret-menu", agent.CreateSecretMenu)
-	mux.HandleFunc("PUT /agent/{agentId}/secret-menu", agent.UpdateSecretMenu)
+	mux.HandleFunc("GET /agent/{agentId}/secret-menu", agent.NewSystem(s.Config).GetSecretMenu)
+	mux.HandleFunc("POST /agent/{agentId}/secret-menu", agent.NewSystem(s.Config).CreateSecretMenu)
+	mux.HandleFunc("PUT /agent/{agentId}/secret-menu", agent.NewSystem(s.Config).UpdateSecretMenu)
 
 	// Stats
-	mux.HandleFunc("GET /stats/agent/environment/{agentId}", stats.NewStatsSystem(s.Config).GetEnvironmentStats)
-	mux.HandleFunc("GET /stats/agent/{agentId}", stats.NewStatsSystem(s.Config).GetAgentStats)
+	mux.HandleFunc("GET /stats/agent/environment/{agentId}", stats.NewSystem(s.Config).GetEnvironmentStats)
+	mux.HandleFunc("GET /stats/agent/{agentId}", stats.NewSystem(s.Config).GetAgentStats)
 
 	// User
-	mux.HandleFunc("POST /user", user.NewUserSystem(s.Config).CreateUser)
-	mux.HandleFunc("GET /user/{userSubject}", user.NewUserSystem(s.Config).GetUser)
+	mux.HandleFunc("POST /user", user.NewSystem(s.Config).CreateUser)
+	mux.HandleFunc("GET /user/{userSubject}", user.NewSystem(s.Config).GetUser)
 
 	// Company
-	mux.HandleFunc("GET /company", company.NewCompanySystem(s.Config).GetCompany)
-	mux.HandleFunc("PUT /company", company.NewCompanySystem(s.Config).UpdateCompany)
-	mux.HandleFunc("POST /company", company.NewCompanySystem(s.Config).CreateCompany)
+	mux.HandleFunc("GET /company", company.NewSystem(s.Config).GetCompany)
+	mux.HandleFunc("PUT /company", company.NewSystem(s.Config).UpdateCompany)
+	mux.HandleFunc("POST /company", company.NewSystem(s.Config).CreateCompany)
 
 	// General
 	mux.HandleFunc(fmt.Sprintf("%s /health", http.MethodGet), healthcheck.HTTP)

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -91,6 +91,6 @@ func (s *Service) startHTTP(errChan chan error) {
 		mw.AddAllowedOrigins("http://localhost:3000", "http://localhost:5173", "*")
 	}
 
-	logs.Infof("Starting HTTP on %d", s.Config.Local.HTTPPort)
+	logs.Logf("Starting HTTP on %d", s.Config.Local.HTTPPort)
 	errChan <- http.ListenAndServe(fmt.Sprintf(":%d", s.Config.Local.HTTPPort), mw.Handler(mux))
 }

--- a/internal/stats/http.go
+++ b/internal/stats/http.go
@@ -14,7 +14,7 @@ type System struct {
 	Context context.Context
 }
 
-func NewStatsSystem(cfg *ConfigBuilder.Config) *System {
+func NewSystem(cfg *ConfigBuilder.Config) *System {
 	return &System{
 		Config: cfg,
 	}

--- a/internal/user/http.go
+++ b/internal/user/http.go
@@ -12,7 +12,7 @@ type System struct {
 	Context context.Context
 }
 
-func NewUserSystem(cfg *ConfigBuilder.Config) *System {
+func NewSystem(cfg *ConfigBuilder.Config) *System {
 	return &System{
 		Config: cfg,
 	}


### PR DESCRIPTION
Add wildcard origin (*) to the list of allowed origins in the Service
middleware for development and production environments. Update the
startHTTP function in service.go to include this change.