### PR TITLE
refactor: move Keycloak details retrieval to separate file

### DIFF
--- a/internal/user/keycloak.go
+++ b/internal/user/keycloak.go
@@ -1,0 +1,26 @@
+package user
+
+import (
+	"github.com/Nerzal/gocloak/v13"
+	"github.com/bugfixes/go-bugfixes/logs"
+	"strings"
+)
+
+func (s *System) GetKeycloakDetails(subject string) (*gocloak.User, error) {
+	client, token, err := s.Config.Keycloak.GetClient(s.Context)
+	if err != nil {
+		if strings.Contains(err.Error(), "ingress.local") {
+			logs.Fatalf("DNS error killing process: %v", err)
+			return nil, nil
+		}
+
+		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to get keycloak client: %v", err)
+	}
+
+	user, err := client.GetUserByID(s.Context, token.AccessToken, s.Config.Keycloak.Realm, subject)
+	if err != nil {
+		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to get user by id: %v", err)
+	}
+
+	return user, nil
+}

--- a/internal/user/postgres.go
+++ b/internal/user/postgres.go
@@ -67,7 +67,7 @@ func (s *System) CreateUserDetails(subject, email, firstname, lastname string) e
 	return nil
 }
 
-func (s *System) RetrieveUserDetails(subject string) (*User, error) {
+func (s *System) RetrieveUserDetailsDB(subject string) (*User, error) {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
 		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)


### PR DESCRIPTION
Refactor the user management code by moving the Keycloak details 
retrieval logic to a new file. Update the function signatures to 
remove unnecessary context parameters and rename the user details 
retrieval function for clarity. This improves code organization 
and readability while maintaining functionality.