### PR TITLE
feat: implement user attachment to company functionality

### DIFF
--- a/internal/company/http.go
+++ b/internal/company/http.go
@@ -10,8 +10,9 @@ import (
 )
 
 type System struct {
-	Config  *ConfigBuilder.Config
-	Context context.Context
+	Config    *ConfigBuilder.Config
+	Context   context.Context
+	CompanyID string
 }
 
 type Company struct {
@@ -154,11 +155,6 @@ func (s *System) AttachUserToCompany(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if user.Domain == "" {
-		w.WriteHeader(http.StatusNotFound)
-		return
-	}
-
 	company, err := s.GetCompanyBasedOnDomain(user.Domain, user.InviteCode)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -167,6 +163,12 @@ func (s *System) AttachUserToCompany(w http.ResponseWriter, r *http.Request) {
 
 	if !company {
 		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	userSubject := r.Header.Get("x-user-subject")
+	if err := s.AttachUserToCompanyDB(userSubject); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 

--- a/internal/company/postgres.go
+++ b/internal/company/postgres.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 )
 
@@ -313,6 +314,55 @@ func (s *System) AttachUserToCompanyDB(userSubject string) error {
 		WHERE subject = $1`, userSubject)
 	if err != nil {
 		return s.Config.Bugfixes.Logger.Errorf("Failed to update user onboarded status: %v", err)
+	}
+
+	return nil
+}
+
+func (s *System) CreateCompanyDB(name, domain, userSubject string) error {
+	client, err := s.Config.Database.GetPGXClient(s.Context)
+	if err != nil {
+		return s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
+	}
+	defer func() {
+		if err := client.Close(s.Context); err != nil {
+			s.Config.Bugfixes.Logger.Fatalf("Failed to close database connection: %v", err)
+		}
+	}()
+
+	companyId := uuid.New().String()
+	inviteCode := uuid.New().String()
+	apiKey := uuid.New().String()
+	apiSecret := uuid.New().String()
+
+	if _, err := client.Exec(s.Context, `
+    INSERT INTO public.company (
+        name,
+        domain,
+        company_id,
+        invite_code,
+        api_key,
+        api_secret
+    ) VALUES (
+        $1,
+        $2,
+        $3,
+        $4,
+        $5,
+        $6
+    )`, name, domain, companyId, inviteCode, apiKey, apiSecret); err != nil {
+		return s.Config.Bugfixes.Logger.Errorf("Failed to insert company into database: %v", err)
+	}
+
+	if _, err := client.Exec(s.Context, `
+    INSERT INTO public.company_user (
+        company_id,
+        user_id
+    ) VALUES (
+        (SELECT id FROM company WHERE company_id = $1),
+        (SELECT id FROM public.user WHERE subject = $2)
+    )`, companyId, userSubject); err != nil {
+		return s.Config.Bugfixes.Logger.Errorf("Failed to insert user into company_user: %v", err)
 	}
 
 	return nil

--- a/internal/user/http.go
+++ b/internal/user/http.go
@@ -147,6 +147,7 @@ func (s *System) GetUser(w http.ResponseWriter, r *http.Request) {
 		user.LastName = kcuser.LastName
 	} else {
 		user = dbuser
+		user.Created = true
 	}
 
 	if err := json.NewEncoder(w).Encode(user); err != nil {

--- a/internal/user/http.go
+++ b/internal/user/http.go
@@ -131,6 +131,7 @@ func (s *System) GetUser(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if kcuser == nil {
+			logs.Logf("User not found in keycloak: %v", subject)
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}

--- a/internal/user/postgres.go
+++ b/internal/user/postgres.go
@@ -12,18 +12,18 @@ type Group struct {
 }
 
 type User struct {
-	Id                *string `json:"id,omitempty"`
-	KnownAs           *string `json:"known_as,omitempty"`
-	Email             *string `json:"email_address,omitempty"`
-	Subject           *string `json:"subject,omitempty"`
-	Timezone          *string `json:"timezone,omitempty"`
-	JobTitle          *string `json:"job_title,omitempty"`
-	Location          *string `json:"location,omitempty"`
-	Avatar            *string `json:"avatar,omitempty"`
-	FirstName         *string `json:"first_name,omitempty"`
-	LastName          *string `json:"last_name,omitempty"`
-	UserGroup         *Group  `json:"user_group,omitempty"`
-	CompanyInviteCode *string `json:"company_invite_code,omitempty"`
+	Id        *string `json:"id,omitempty"`
+	KnownAs   *string `json:"known_as,omitempty"`
+	Email     *string `json:"email_address,omitempty"`
+	Subject   *string `json:"subject,omitempty"`
+	Timezone  *string `json:"timezone,omitempty"`
+	JobTitle  *string `json:"job_title,omitempty"`
+	Location  *string `json:"location,omitempty"`
+	Avatar    *string `json:"avatar,omitempty"`
+	FirstName *string `json:"first_name,omitempty"`
+	LastName  *string `json:"last_name,omitempty"`
+	UserGroup *Group  `json:"user_group,omitempty"`
+	Onboarded *bool   `json:"onboarded,omitempty"`
 }
 
 type Notification struct {
@@ -98,13 +98,12 @@ func (s *System) RetrieveUserDetailsDB(subject string) (*User, error) {
         u.first_name,
         u.last_name,
         u.user_group_id,
-    	ug.name AS user_group_name,
-    	c.invite_code
+        u.onboarded,
+    	ug.name AS user_group_name
     FROM public.user AS u
     	LEFT JOIN public.user_groups AS ug ON ug.id = u.user_group_id
     	LEFT JOIN public.company_user AS cu ON cu.user_id = u.id
-        LEFT JOIN public.company AS c ON c.id = cu.company_id
-    WHERE subject = $1`, subject).Scan(&user.Id, &user.KnownAs, &user.Email, &user.Subject, &user.Timezone, &user.JobTitle, &user.Location, &user.Avatar, &user.FirstName, &user.LastName, &ug.Id, &ug.Name, &user.CompanyInviteCode); err != nil {
+    WHERE subject = $1`, subject).Scan(&user.Id, &user.KnownAs, &user.Email, &user.Subject, &user.Timezone, &user.JobTitle, &user.Location, &user.Avatar, &user.FirstName, &user.LastName, &ug.Id, &user.Onboarded, &ug.Name); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}


### PR DESCRIPTION
Add functionality to attach a user to a company based on the user 
subject received in the request header. Update the database to 
insert the user into the company_user table and set the user's 
onboarded status to true. Remove unnecessary checks and improve 
error handling for database operations.