### PR TITLE
feat: add endpoint to retrieve company users

### DIFF
--- a/internal/service.go
+++ b/internal/service.go
@@ -112,6 +112,7 @@ func (s *Service) startHTTP(errChan chan error) {
 	mux.HandleFunc("GET /company/limits", company.NewSystem(s.Config).GetCompanyLimits)
 	mux.HandleFunc("GET /company/pricing", pricing.NewSystem(s.Config).GetCompanyPricing)
 	mux.HandleFunc("PUT /company/user", company.NewSystem(s.Config).AttachUserToCompany)
+	mux.HandleFunc("GET /company/users", company.NewSystem(s.Config).GetCompanyUsers)
 
 	// General
 	mux.HandleFunc(fmt.Sprintf("%s /health", http.MethodGet), healthcheck.HTTP)


### PR DESCRIPTION
Implements a new HTTP GET endpoint for fetching users 
associated with a company. This change enhances the 
service's functionality by allowing clients to access 
user information linked to a specific company. The 
new endpoint is integrated into the existing routing 
and includes necessary database queries to retrieve 
user data.