### PR TITLE
feat: refactor company limits retrieval and add new endpoint

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 1
       - name: Meta
         id: meta

--- a/.github/workflows/drafter.yml
+++ b/.github/workflows/drafter.yml
@@ -20,6 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}  # to check out the actual pull request commit, not the merge commit
           fetch-depth: 0  # a full history is required for pull request analysis
       - name: 'Qodana Scan'

--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -18,6 +18,7 @@ jobs:
           go-version: 1.22.x
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 1
       - name: test
         run: go test -v -race -bench=./... -benchmem -timeout=120s -bench=./... ./...
@@ -31,6 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - name: 'Qodana Scan'

--- a/internal/company/http.go
+++ b/internal/company/http.go
@@ -115,36 +115,47 @@ func (s *System) GetCompanyLimits(w http.ResponseWriter, r *http.Request) {
 	}
 
 	userSubject := r.Header.Get("x-user-subject")
-
-	projectLimits, err := s.GetProjectLimits(userSubject)
+	companyId, err := s.GetCompanyId(userSubject)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
-	userLimits, err := s.GetUserLimits(userSubject)
+	limits, err := s.GetLimits(companyId)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
-	agentLimits, err := s.GetAgentLimits(userSubject)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	if userLimits == nil || projectLimits == nil {
-		w.WriteHeader(http.StatusNotFound)
-		return
-	}
-
-	// This is a dummy response
-	limits := Limits{
-		Projects: *projectLimits,
-		Users:    *userLimits,
-		Agents:   *agentLimits,
-	}
+	//projectLimits, err := s.GetProjectLimits(userSubject)
+	//if err != nil {
+	//	w.WriteHeader(http.StatusInternalServerError)
+	//	return
+	//}
+	//
+	//userLimits, err := s.GetUserLimits(userSubject)
+	//if err != nil {
+	//	w.WriteHeader(http.StatusInternalServerError)
+	//	return
+	//}
+	//
+	//agentLimits, err := s.GetAgentLimits(userSubject)
+	//if err != nil {
+	//	w.WriteHeader(http.StatusInternalServerError)
+	//	return
+	//}
+	//
+	//if userLimits == nil || projectLimits == nil {
+	//	w.WriteHeader(http.StatusNotFound)
+	//	return
+	//}
+	//
+	//// This is a dummy response
+	//limits := Limits{
+	//	Projects: *projectLimits,
+	//	Users:    *userLimits,
+	//	Agents:   *agentLimits,
+	//}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(&limits); err != nil {

--- a/internal/service.go
+++ b/internal/service.go
@@ -52,6 +52,7 @@ func (s *Service) startHTTP(errChan chan error) {
 	mux.HandleFunc("GET /project/{projectId}", project.NewSystem(s.Config).GetProject)
 	mux.HandleFunc("PUT /project/{projectId}", project.NewSystem(s.Config).UpdateProject)
 	mux.HandleFunc("PUT /project/{projectId}/image", project.NewSystem(s.Config).UpdateProjectImage)
+	mux.HandleFunc("GET /project/{projectId}/limits", project.NewSystem(s.Config).GetLimits)
 	mux.HandleFunc("DELETE /project/{projectId}", project.NewSystem(s.Config).DeleteProject)
 
 	// Agents


### PR DESCRIPTION
Refactor the GetCompanyLimits function to streamline the process of 
retrieving limits by using a single GetLimits method. Remove unused 
code related to project, user, and agent limits. 

Add a new GetLimits endpoint in the project service to fetch