### PR TITLE
refactor: comment out Qodana job configurations

### DIFF
--- a/.github/workflows/drafter.yml
+++ b/.github/workflows/drafter.yml
@@ -8,22 +8,22 @@ permissions:
   contents: read
 
 jobs:
-  qodana:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      checks: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-          ref: ${{ github.event.pull_request.head.sha }}  # to check out the actual pull request commit, not the merge commit
-          fetch-depth: 0  # a full history is required for pull request analysis
-      - name: 'Qodana Scan'
-        uses: JetBrains/qodana-action@v2023.3
-        env:
-          QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
+#  qodana:
+#    runs-on: ubuntu-latest
+#    permissions:
+#      contents: write
+#      pull-requests: write
+#      checks: write
+#    steps:
+#      - uses: actions/checkout@v4
+#        with:
+#          persist-credentials: false
+#          ref: ${{ github.event.pull_request.head.sha }}  # to check out the actual pull request commit, not the merge commit
+#          fetch-depth: 0  # a full history is required for pull request analysis
+#      - name: 'Qodana Scan'
+#        uses: JetBrains/qodana-action@v2023.3
+#        env:
+#          QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
   update_release_draft:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -22,25 +22,25 @@ jobs:
           fetch-depth: 1
       - name: test
         run: go test -v -race -bench=./... -benchmem -timeout=120s -bench=./... ./...
-  qodana:
-    needs: test
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      checks: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-      - name: 'Qodana Scan'
-        uses: JetBrains/qodana-action@v2023.3.2
-        with:
-          upload-result: true
-        env:
-          QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
+#  qodana:
+#    needs: test
+#    runs-on: ubuntu-latest
+#    permissions:
+#      contents: write
+#      pull-requests: write
+#      checks: write
+#    steps:
+#      - uses: actions/checkout@v4
+#        with:
+#          persist-credentials: false
+#          ref: ${{ github.event.pull_request.head.sha }}
+#          fetch-depth: 0
+#      - name: 'Qodana Scan'
+#        uses: JetBrains/qodana-action@v2023.3.2
+#        with:
+#          upload-result: true
+#        env:
+#          QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
   auto-merge:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Comment out the Qodana job configurations in the GitHub Actions  workflows to temporarily disable the static code analysis step.  This change is made to streamline the CI process while  investigating issues with the Qodana integration.