### PR TITLE
feat: retrieve resend key from vault for email invites

### DIFF
--- a/cmd/orchestrator/service.go
+++ b/cmd/orchestrator/service.go
@@ -33,7 +33,17 @@ func (pc ProjectConfig) Build(cfg *ConfigBuilder.Config) error {
 		cfg.ProjectProperties = make(map[string]interface{})
 	}
 	cfg.ProjectProperties["flagsService"] = p.FlagsService
-	cfg.ProjectProperties["resendKey"] = p.ResendKey
+
+	// get the resend key out of the vault
+	vh := *cfg.VaultHelper
+	if vh.Secrets() == nil {
+		return logs.Error("no secrets found")
+	}
+	secret, err := vh.GetSecret("resend_key")
+	if err != nil {
+		return logs.Errorf("failed to get resend key: %v", err)
+	}
+	cfg.ProjectProperties["resendKey"] = secret
 
 	return nil
 }

--- a/internal/company/http.go
+++ b/internal/company/http.go
@@ -313,7 +313,7 @@ func (s *System) InviteUserToCompany(w http.ResponseWriter, r *http.Request) {
 	// Create the invite
 	client := resend.NewClient(s.Config.ProjectProperties["resendKey"].(string))
 	params := &resend.SendEmailRequest{
-		From:    "Flags <support@flags.gg>",
+		From:    "Flags.gg <support@flags.gg>",
 		To:      []string{invite.Email},
 		Subject: "Flags.gg Invite",
 		Html:    fmt.Sprintf("<p>Hello: %s<br />You have been invited to join <a href=\"https://flags.gg\">Flags.gg</a></p><br /><p>The invite code is <strong>%s</strong></p>", invite.Name, inviteCode),


### PR DESCRIPTION
Fetch the resend key from the vault instead of using a hardcoded value. 
This change ensures that sensitive information is securely managed and 
retrieved dynamically, enhancing security and maintainability. Also, 
update the email sender format for consistency.