### PR TITLE
fix: update golang base image to alpine3.20

### DIFF
--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
       - uses: actions/checkout@v4
         with:
           persist-credentials: false

--- a/k8s/Containerfile
+++ b/k8s/Containerfile
@@ -1,5 +1,5 @@
 # Build
-FROM containers.chewed-k8s.net/docker_hub_cache/library/golang:alpine3.18 AS builder
+FROM containers.chewed-k8s.net/docker_hub_cache/library/golang:alpine3.20 AS builder
 
 RUN mkdir -p /home/builder
 WORKDIR /home/builder


### PR DESCRIPTION
Update the base image in the Containerfile from 
alpine3.18 to alpine3.20 to ensure compatibility 
with the latest features and security updates.