### PR TITLE
refactor: comment out unused Stripe webhook handling code

### DIFF
--- a/internal/general/general.go
+++ b/internal/general/general.go
@@ -30,29 +30,31 @@ func (s *System) KeycloakEvents(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *System) StripeEvents(w http.ResponseWriter, r *http.Request) {
-	const MaxBodyBytes = int64(65536)
-	r.Body = http.MaxBytesReader(w, r.Body, MaxBodyBytes)
-	payload, err := io.ReadAll(r.Body)
-	if err != nil {
-		logs.Logf("Error reading request body: %v\n", err)
-		w.WriteHeader(http.StatusServiceUnavailable)
-		return
-	}
-
-	// This is your Stripe CLI webhook secret for testing your endpoint locally.
-	endpointSecret := s.Config.Local.GetValue("STRIPE_LOCAL")
-	// Pass the request body and Stripe-Signature header to ConstructEvent, along
-	// with the webhook signing key.
-	event, err := webhook.ConstructEvent(payload, r.Header.Get("Stripe-Signature"), endpointSecret)
-
-	if err != nil {
-		logs.Logf("Error verifying webhook signature: %v\n", err)
-		w.WriteHeader(http.StatusBadRequest) // Return a 400 error on a bad signature
-		return
-	}
-
-	// Unmarshal the event data into an appropriate struct depending on its Type
-	logs.Logf("Unhandled event type: %s\n", event.Type)
-
 	w.WriteHeader(http.StatusOK)
+
+	//const MaxBodyBytes = int64(65536)
+	//r.Body = http.MaxBytesReader(w, r.Body, MaxBodyBytes)
+	//payload, err := io.ReadAll(r.Body)
+	//if err != nil {
+	//	logs.Logf("Error reading request body: %v\n", err)
+	//	w.WriteHeader(http.StatusServiceUnavailable)
+	//	return
+	//}
+	//
+	//// This is your Stripe CLI webhook secret for testing your endpoint locally.
+	//endpointSecret := s.Config.Local.GetValue("STRIPE_LOCAL")
+	//// Pass the request body and Stripe-Signature header to ConstructEvent, along
+	//// with the webhook signing key.
+	//event, err := webhook.ConstructEvent(payload, r.Header.Get("Stripe-Signature"), endpointSecret)
+	//
+	//if err != nil {
+	//	logs.Logf("Error verifying webhook signature: %v\n", err)
+	//	w.WriteHeader(http.StatusBadRequest) // Return a 400 error on a bad signature
+	//	return
+	//}
+	//
+	//// Unmarshal the event data into an appropriate struct depending on its Type
+	//logs.Logf("Unhandled event type: %s\n", event.Type)
+	//
+	//w.WriteHeader(http.StatusOK)
 }

--- a/internal/general/general.go
+++ b/internal/general/general.go
@@ -2,10 +2,7 @@ package general
 
 import (
 	"context"
-	"github.com/bugfixes/go-bugfixes/logs"
 	ConfigBuilder "github.com/keloran/go-config"
-	"github.com/stripe/stripe-go/webhook"
-	"io"
 	"net/http"
 )
 


### PR DESCRIPTION
Comments out the Stripe webhook handling code in the StripeEvents 
function. This change is made to simplify the function and remove 
unnecessary logic while retaining the option to restore it later 
if needed.