### PR TITLE
fix: handle canceled database connection errors

### DIFF
--- a/internal/agent/postgres.go
+++ b/internal/agent/postgres.go
@@ -7,6 +7,7 @@ import (
 	"github.com/flags-gg/orchestrator/internal/environment"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"strings"
 )
 
 type ProjectInfo struct {
@@ -28,6 +29,9 @@ type Agent struct {
 func (s *System) CreateAgentForProject(name, projectId string) (string, error) {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return "", nil
+		}
 		return "", s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -57,6 +61,9 @@ func (s *System) CreateAgentForProject(name, projectId string) (string, error) {
 func (s *System) GetAgentDetails(agentId, companyId string) (*Agent, error) {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil, nil
+		}
 		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -112,6 +119,9 @@ func (s *System) GetAgentDetails(agentId, companyId string) (*Agent, error) {
 func (s *System) GetAgents(companyId string) ([]*Agent, error) {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil, nil
+		}
 		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -165,6 +175,9 @@ func (s *System) GetAgents(companyId string) ([]*Agent, error) {
 func (s *System) GetAgentsForProject(companyId, projectId string) ([]*Agent, error) {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil, nil
+		}
 		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -219,7 +232,9 @@ func (s *System) ValidateAgentWithEnvironment(ctx context.Context, agentId, proj
 
 	client, err := s.Config.Database.GetPGXClient(ctx)
 	if err != nil {
-		logs.Logf("validate agent: %+v", s.Config.Database)
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return false, nil
+		}
 		return false, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -254,6 +269,9 @@ func (s *System) ValidateAgentWithoutEnvironment(ctx context.Context, agentId, p
 
 	client, err := s.Config.Database.GetPGXClient(ctx)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return false, nil
+		}
 		return false, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -283,6 +301,9 @@ func (s *System) ValidateAgentWithoutEnvironment(ctx context.Context, agentId, p
 func (s *System) CreateAgentInDB(name, projectId string) (*Agent, error) {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil, nil
+		}
 		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -318,6 +339,9 @@ func (s *System) CreateAgentInDB(name, projectId string) (*Agent, error) {
 func (s *System) UpdateAgentDetails(agent Agent) error {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil
+		}
 		return s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -340,6 +364,9 @@ func (s *System) UpdateAgentDetails(agent Agent) error {
 func (s *System) DeleteAgentFromDB(agentId string) error {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil
+		}
 		return s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -361,6 +388,9 @@ func (s *System) DeleteAgentFromDB(agentId string) error {
 func (s *System) DeleteAllAgentsForProject(projectId string) error {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil
+		}
 		return s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {

--- a/internal/company/postgres.go
+++ b/internal/company/postgres.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/checkout/session"
+	"strings"
 )
 
 type Agents struct {
@@ -62,6 +63,9 @@ func (s *System) GetProjectLimits(userSubject string) (*Projects, error) {
 
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil, nil
+		}
 		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -104,6 +108,9 @@ func (s *System) GetUserLimits(userSubject string) (*Users, error) {
 
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil, nil
+		}
 		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -143,6 +150,9 @@ func (s *System) GetAgentLimits(companyId string) (*Agents, error) {
 
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil, nil
+		}
 		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -209,7 +219,9 @@ func (s *System) GetAgentLimits(companyId string) (*Agents, error) {
 func (s *System) GetCompanyId(userSubject string) (string, error) {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
-		logs.Logf("Failed to connect to database: %+v", s.Config.Database)
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return "", nil
+		}
 		return "", s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -250,6 +262,9 @@ func (s *System) GetCompanyInfo(userSubject string) (*Details, error) {
 
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil, nil
+		}
 		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -317,6 +332,9 @@ func (s *System) GetCompanyInfo(userSubject string) (*Details, error) {
 func (s *System) GetCompanyBasedOnDomain(domain, inviteCode string) (bool, error) {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return false, nil
+		}
 		return false, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -346,6 +364,9 @@ func (s *System) GetCompanyBasedOnDomain(domain, inviteCode string) (bool, error
 func (s *System) AttachUserToCompanyDB(userSubject string) error {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil
+		}
 		return s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -380,6 +401,9 @@ func (s *System) AttachUserToCompanyDB(userSubject string) error {
 func (s *System) CreateCompanyDB(name, domain, userSubject string) error {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil
+		}
 		return s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -438,6 +462,9 @@ func (s *System) GetCompanyUsersFromDB(companyId string) ([]User, error) {
 
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return users, nil
+		}
 		return users, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -483,6 +510,9 @@ func (s *System) GetLimits(companyId string) (Limits, error) {
 
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return limits, nil
+		}
 		return limits, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -535,6 +565,9 @@ func (s *System) GetLimits(companyId string) (Limits, error) {
 func (s *System) UpdateCompanyImageInDB(companyId, image string) error {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil
+		}
 		return s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -555,6 +588,9 @@ func (s *System) UpdateCompanyImageInDB(companyId, image string) error {
 func (s *System) GetInviteCodeFromDB(companyId string) (string, error) {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return "", nil
+		}
 		return "", s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -578,6 +614,9 @@ func (s *System) GetInviteCodeFromDB(companyId string) (string, error) {
 func (s *System) UpgradeCompanyInDB(companyId, stripeSessionId string) error {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil
+		}
 		return s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {

--- a/internal/environment/postgres.go
+++ b/internal/environment/postgres.go
@@ -8,11 +8,15 @@ import (
 	"github.com/flags-gg/orchestrator/internal/secretmenu"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"strings"
 )
 
 func (s *System) CreateEnvironmentInDB(name, agentId string) (*Environment, error) {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil, nil
+		}
 		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -48,6 +52,9 @@ func (s *System) CreateEnvironmentInDB(name, agentId string) (*Environment, erro
 func (s *System) GetEnvironmentFromDB(envId, companyId string) (*Environment, error) {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil, nil
+		}
 		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -86,6 +93,9 @@ func (s *System) GetEnvironmentFromDB(envId, companyId string) (*Environment, er
 func (s *System) GetAgentEnvironmentsFromDB(agentId, companyId string) ([]*Environment, error) {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil, nil
+		}
 		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -130,6 +140,9 @@ func (s *System) GetAgentEnvironmentsFromDB(agentId, companyId string) ([]*Envir
 func (s *System) GetEnvironmentsFromDB(companyId string) ([]*Environment, error) {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil, nil
+		}
 		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -173,6 +186,9 @@ func (s *System) GetEnvironmentsFromDB(companyId string) ([]*Environment, error)
 func (s *System) UpdateEnvironmentInDB(env Environment) error {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil
+		}
 		return s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -195,6 +211,9 @@ func (s *System) UpdateEnvironmentInDB(env Environment) error {
 func (s *System) CloneEnvironmentInDB(envId, newEnvId, agentId, name string) error {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil
+		}
 		return s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -252,6 +271,9 @@ func (s *System) CloneEnvironmentInDB(envId, newEnvId, agentId, name string) err
 func (s *System) DeleteEnvironmentFromDB(envId string) error {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil
+		}
 		return s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -280,6 +302,9 @@ func (s *System) DeleteEnvironmentFromDB(envId string) error {
 func (s *System) DeleteAllEnvironmentsForAgent(agentId string) error {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil
+		}
 		return s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {

--- a/internal/flags/agent.go
+++ b/internal/flags/agent.go
@@ -19,6 +19,9 @@ func (s *System) GetAgentFlagsFromDB(projectId, agentId, environmentId string) (
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
 		stats.NewSystem(s.Config).AddAgentError(projectId, agentId, environmentId)
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil, nil
+		}
 		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -185,6 +188,9 @@ func (s *System) GetAgentFlagsFromDB(projectId, agentId, environmentId string) (
 func (s *System) GetDefaultEnvironment(projectId, agentId string) (string, error) {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return "", nil
+		}
 		return "", s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {

--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
+	"strings"
 )
 
 type Extra struct {
@@ -33,6 +34,9 @@ type Price struct {
 func (s *System) GetPrices() ([]Price, error) {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil, nil
+		}
 		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -90,6 +94,9 @@ func (s *System) GetPrices() ([]Price, error) {
 func (s *System) GetPrice(title string) (Price, error) {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return Price{}, nil
+		}
 		return Price{}, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {

--- a/internal/project/postgres.go
+++ b/internal/project/postgres.go
@@ -7,6 +7,7 @@ import (
 	"github.com/flags-gg/orchestrator/internal/agent"
 	"github.com/flags-gg/orchestrator/internal/environment"
 	"github.com/google/uuid"
+	"strings"
 )
 
 type Project struct {
@@ -22,6 +23,9 @@ type Project struct {
 func (s *System) GetProjectsFromDB(companyId string) ([]Project, error) {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil, nil
+		}
 		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -77,6 +81,9 @@ func (s *System) GetProjectsFromDB(companyId string) ([]Project, error) {
 func (s *System) GetProjectFromDB(companyId, projectId string) (*Project, error) {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil, nil
+		}
 		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -118,6 +125,9 @@ func (s *System) GetProjectFromDB(companyId, projectId string) (*Project, error)
 func (s *System) CreateProjectInDB(companyId, projectName string) (*Project, error) {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil, nil
+		}
 		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -165,6 +175,9 @@ func (s *System) CreateProjectInDB(companyId, projectName string) (*Project, err
 func (s *System) UpdateProjectInDB(projectId, projectName string, enabled bool) (*Project, error) {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil, nil
+		}
 		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -190,6 +203,9 @@ func (s *System) UpdateProjectInDB(projectId, projectName string, enabled bool) 
 func (s *System) DeleteProjectInDB(projectId string) error {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil
+		}
 		return s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -210,6 +226,9 @@ func (s *System) DeleteProjectInDB(projectId string) error {
 func (s *System) UpdateProjectImageInDB(projectId, logo string) error {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil
+		}
 		return s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -238,6 +257,9 @@ func (s *System) GetLimitsFromDB(companyId, projectId string) (AgentLimits, erro
 
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return limits, nil
+		}
 		return limits, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {

--- a/internal/secretmenu/postgres.go
+++ b/internal/secretmenu/postgres.go
@@ -127,6 +127,9 @@ func (s *System) GetEnvironmentSecretMenu(environmentId string) (SecretMenu, err
 
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return secretMenu, nil
+		}
 		return secretMenu, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -186,6 +189,9 @@ func (s *System) GetSecretMenuFromDB(menuId string) (SecretMenu, error) {
 
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return secretMenu, nil
+		}
 		return secretMenu, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -249,6 +255,9 @@ func (s *System) GetSecretMenuFromDB(menuId string) (SecretMenu, error) {
 func (s *System) UpdateSecretMenuSequenceInDB(menuId string, secretMenu SecretMenu) error {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil
+		}
 		return s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -271,6 +280,9 @@ func (s *System) UpdateSecretMenuSequenceInDB(menuId string, secretMenu SecretMe
 func (s *System) UpdateSecretMenuStateInDB(menuId string) error {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil
+		}
 		return s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -292,6 +304,9 @@ func (s *System) UpdateSecretMenuStateInDB(menuId string) error {
 func (s *System) UpdateSecretMenuStyleInDB(menuId string, secretMenu SecretMenu) error {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil
+		}
 		return s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -356,6 +371,9 @@ func (s *System) UpdateSecretMenuStyleInDB(menuId string, secretMenu SecretMenu)
 func (s *System) CreateSecretMenuInDB(environmentId string, secretMenu SecretMenu) (string, string, error) {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return "", "", nil
+		}
 		return "", "", s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -428,6 +446,9 @@ func (s *System) CreateSecretMenuInDB(environmentId string, secretMenu SecretMen
 func (s *System) DeleteSecretMenuForEnv(envId string) error {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil
+		}
 		return s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -457,6 +478,9 @@ func (s *System) GetSecretMenuStyleFromDB(menuId string) (StyleMenu, error) {
 
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return styleMenu, nil
+		}
 		return styleMenu, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {

--- a/internal/stats/postgres.go
+++ b/internal/stats/postgres.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/bugfixes/go-bugfixes/logs"
 	"github.com/jackc/pgx/v5"
+	"strings"
 )
 
 func (s *System) GetNamesForData(data *AgentStat) (*AgentStat, error) {
@@ -29,6 +30,9 @@ func (s *System) GetNamesForData(data *AgentStat) (*AgentStat, error) {
 func (s *System) GetAgentName(agentId string) (string, error) {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return "", nil
+		}
 		return "", s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -58,6 +62,9 @@ func (s *System) GetAgentName(agentId string) (string, error) {
 func (s *System) GetEnvironmentName(environmentId string) (string, error) {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return "", nil
+		}
 		return "", s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {

--- a/internal/user/postgres.go
+++ b/internal/user/postgres.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"github.com/jackc/pgx/v5"
+	"strings"
 	"time"
 )
 
@@ -44,6 +45,9 @@ type Notifications struct {
 func (s *System) CreateUserDetails(subject, knownAs, email, firstname, lastname, location string, userGroup int) error {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil
+		}
 		return s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -77,6 +81,9 @@ func (s *System) CreateUserDetails(subject, knownAs, email, firstname, lastname,
 func (s *System) RetrieveUserDetailsDB(subject string) (*User, error) {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil, nil
+		}
 		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -138,6 +145,9 @@ func (s *System) RetrieveUserDetailsDB(subject string) (*User, error) {
 func (s *System) RetrieveUserNotifications(subject string) ([]Notification, error) {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil, nil
+		}
 		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -181,6 +191,9 @@ func (s *System) RetrieveUserNotifications(subject string) ([]Notification, erro
 func (s *System) MarkNotificationAsRead(subject, notificationId string) error {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil
+		}
 		return s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -205,6 +218,9 @@ func (s *System) MarkNotificationAsRead(subject, notificationId string) error {
 func (s *System) DeleteUserNotificationInDB(subject, notificationId string) error {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil
+		}
 		return s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -231,6 +247,9 @@ func (s *System) DeleteUserNotificationInDB(subject, notificationId string) erro
 func (s *System) UpdateUserImageInDB(subject string, image string) error {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil
+		}
 		return s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -251,6 +270,9 @@ func (s *System) UpdateUserImageInDB(subject string, image string) error {
 func (s *System) UpdateUserDetailsDB(subject, knownAs, email, firstname, lastname, location string) error {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil
+		}
 		return s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
@@ -278,6 +300,9 @@ func (s *System) UpdateUserDetailsDB(subject, knownAs, email, firstname, lastnam
 func (s *System) DeleteUserInDB(subject string) error {
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil
+		}
 		return s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {


### PR DESCRIPTION
Add checks for "operation was canceled" errors in multiple database 
connection functions. Return nil or default values instead of logging 
errors when this specific error occurs, improving the handling of 
canceled operations and preventing unnecessary error logs.