### PR TITLE
feat(deps): update go-config dependency to v1.5.5

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -55,8 +55,8 @@ tasks:
         vars:
           COMMIT_HASH:
             sh: cat .commit_hash
-      - nerdctl push containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:{{.COMMIT_HASH}} --all-platforms
-      - nerdctl push containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:latest --all-platforms
+      - docker push containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:{{.COMMIT_HASH}} --all-platforms
+      - docker push containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:latest --all-platforms
     vars:
       COMMIT_HASH:
         sh: cat .commit_hash
@@ -66,7 +66,7 @@ tasks:
         vars:
           COMMIT_HASH:
             sh: cat .commit_hash
-      - nerdctl push containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:{{.COMMIT_HASH}} --all-platforms
+      - docker push containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:{{.COMMIT_HASH}} --all-platforms
     vars:
       COMMIT_HASH:
         sh: cat .commit_hash
@@ -82,8 +82,8 @@ tasks:
         vars:
           COMMIT_HASH:
             sh: cat .commit_hash
-      - nerdctl build --platform=amd64,arm64 --tag containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:{{.COMMIT_HASH}} --build-arg VERSION={{.LATEST_TAG}} --build-arg BUILD={{.COMMIT_HASH}} --build-arg SERVICE_NAME={{.SERVICE_NAME}} -f ./k8s/Containerfile .
-      - nerdctl tag containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:{{.COMMIT_HASH}} containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:latest
+      - docker build --tag containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:{{.COMMIT_HASH}} --build-arg VERSION={{.LATEST_TAG}} --build-arg BUILD={{.COMMIT_HASH}} --build-arg SERVICE_NAME={{.SERVICE_NAME}} -f ./k8s/Containerfile .
+      - docker tag containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:{{.COMMIT_HASH}} containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:latest
     vars:
       LATEST_TAG:
         sh: cat .latest_tag
@@ -95,7 +95,7 @@ tasks:
         vars:
           COMMIT_HASH:
             sh: cat .commit_hash
-      - nerdctl build --platform=amd64,arm64 --tag containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:{{.COMMIT_HASH}} --build-arg VERSION={{.LATEST_TAG}} --build-arg BUILD={{.COMMIT_HASH}} --build-arg SERVICE_NAME={{.SERVICE_NAME}} -f ./k8s/Containerfile .
+      - docker build --tag containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:{{.COMMIT_HASH}} --build-arg VERSION={{.LATEST_TAG}} --build-arg BUILD={{.COMMIT_HASH}} --build-arg SERVICE_NAME={{.SERVICE_NAME}} -f ./k8s/Containerfile .
     vars:
       LATEST_TAG:
         sh: cat .latest_tag
@@ -105,8 +105,8 @@ tasks:
     cmds:
       - task: get-latest-tag
       - task: get-commit-hash
-      - nerdctl build --platform=amd64,arm64 --tag containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:latest --build-arg VERSION={{.LATEST_TAG}} --build-arg BUILD={{.COMMIT_HASH}} --build-arg SERVICE_NAME={{.SERVICE_NAME}} -f ./k8s/Containerfile .
-      - nerdctl push containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:latest --all-platforms
+      - docker build --tag containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:latest --build-arg VERSION={{.LATEST_TAG}} --build-arg BUILD={{.COMMIT_HASH}} --build-arg SERVICE_NAME={{.SERVICE_NAME}} -f ./k8s/Containerfile .
+      - docker push containers.chewed-k8s.net/{{.NAMESPACE}}/{{.SERVICE_NAME}}:latest --all-platforms
     vars:
       LATEST_TAG:
         sh: cat .latest_tag

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0
 	github.com/jackc/pgx/v5 v5.7.2
-	github.com/keloran/go-config v1.5.4
+	github.com/keloran/go-config v1.5.5
 	github.com/keloran/go-healthcheck v1.2.2
 	github.com/keloran/go-probe v1.0.0
 	github.com/keloran/vault-helper v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,8 @@ github.com/keloran/go-config v1.5.3 h1:OYtcrtfZYGljDUGe5qsRUjqqrJCRKh8ZoXS9qxnNA
 github.com/keloran/go-config v1.5.3/go.mod h1:i07NHq/+JcuR3MiIRBu//u9uqKM/2hn/Zvxfq/otBwg=
 github.com/keloran/go-config v1.5.4 h1:jUbhcCL2Y/4EAzfTnQsJUB1Hv0Rdi9j7NDGJd3zmyRs=
 github.com/keloran/go-config v1.5.4/go.mod h1:i07NHq/+JcuR3MiIRBu//u9uqKM/2hn/Zvxfq/otBwg=
+github.com/keloran/go-config v1.5.5 h1:u27fqQXDfm0b11vd6vl3+MY31tPXS9wi0KQYKB+JPaE=
+github.com/keloran/go-config v1.5.5/go.mod h1:i07NHq/+JcuR3MiIRBu//u9uqKM/2hn/Zvxfq/otBwg=
 github.com/keloran/go-healthcheck v1.2.2 h1:C92m/ppWkY6OldY5RrDiqCTpXIaOZtSO0vMmHADsrUc=
 github.com/keloran/go-healthcheck v1.2.2/go.mod h1:XGZyWC9IMGoyMGUvh3v3cZQp+eHFuYCHIkDjQOsuUVk=
 github.com/keloran/go-probe v1.0.0 h1:OAO7f71lRJIz+rF7iGAeBj4i86NaUazL8DaVf9dVJGU=


### PR DESCRIPTION
The changes update the go-config dependency from v1.5.4 to v1.5.5. This update is necessary to incorporate the latest bug fixes and improvements in the go-config library.

Additionally, the Taskfile.yml file has been updated to use the `docker` command instead of `nerdctl` for building and pushing container images. This change ensures compatibility with the deployment environment.