### PR TITLE
feat(secretmenu): Update table names in secret menu queries

### DIFF
--- a/internal/agent/postgres.go
+++ b/internal/agent/postgres.go
@@ -246,7 +246,7 @@ func (s *System) ValidateAgentWithEnvironment(ctx context.Context, agentId, proj
 	if err := client.QueryRow(ctx, `
     SELECT TRUE
     FROM public.agent
-      JOIN public.agent_environment AS pa ON pa.agent_id = agent.id
+      JOIN public.environment AS pa ON pa.agent_id = agent.id
       JOIN public.project ON project.id = agent.project_id
     WHERE agent.agent_id = $1
       AND pa.env_id = $2

--- a/internal/flags/agent.go
+++ b/internal/flags/agent.go
@@ -66,16 +66,15 @@ func (s *System) GetAgentFlagsFromDB(projectId, agentId, environmentId string) (
       menuStyle.header AS Header,
       agent.interval
     FROM public.agent
-      LEFT JOIN public.environment_flag AS flags ON agent.id = flags.agent_id
-      LEFT JOIN public.agent_environment AS env ON env.id = flags.environment_id
+      LEFT JOIN public.flag AS flags ON agent.id = flags.agent_id
+      LEFT JOIN public.environment AS env ON env.id = flags.environment_id
       LEFT JOIN public.project ON project.id = agent.project_id
-      LEFT JOIN public.environment_secret_menu AS secretMenu ON secretMenu.agent_id = agent.id
+      LEFT JOIN public.secret_menu AS secretMenu ON secretMenu.agent_id = agent.id
 		AND secretMenu.environment_id = env.id
       LEFT JOIN public.secret_menu_style AS menuStyle ON menuStyle.secret_menu_id = secretMenu.id
     WHERE env.env_id = $1
       AND agent.agent_id = $2
       AND project.project_id = $3
-      AND agent.enabled = true
       AND agent.enabled = true
       AND project.enabled = true`, environmentId, agentId, projectId)
 	if err != nil {
@@ -202,7 +201,7 @@ func (s *System) GetDefaultEnvironment(projectId, agentId string) (string, error
 	var envId string
 	err = client.QueryRow(s.Context, `
     SELECT env.env_id
-    FROM public.agent_environment AS env
+    FROM public.environment AS env
       JOIN public.agent ON env.agent_id = agent.id
       JOIN public.project ON agent.project_id = project.id
     WHERE agent.agent_id = $1

--- a/internal/stats/postgres.go
+++ b/internal/stats/postgres.go
@@ -76,7 +76,7 @@ func (s *System) GetEnvironmentName(environmentId string) (string, error) {
 	var envName string
 	if err := client.QueryRow(s.Context, `
     SELECT env.name AS EnvName
-    FROM public.agent_environment AS env
+    FROM public.environment AS env
     WHERE env_id = $1`, environmentId).Scan(&envName); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return "", nil


### PR DESCRIPTION
The changes in this commit update the table names used in the secret menu queries to match the updated schema. The main changes are:

- Updating the table name from `environment_secret_menu` to `secret_menu`
- Updating the table name from `environment_flag` to `flag`
- Updating the table name from `agent_environment` to `environment`

These changes are necessary to ensure the queries are using the correct table names and to maintain compatibility with the updated database schema.