### PR TITLE
feat(project): Change project creation error response

### DIFF
--- a/cmd/orchestrator/service.go
+++ b/cmd/orchestrator/service.go
@@ -24,6 +24,7 @@ func (pc ProjectConfig) Build(cfg *ConfigBuilder.Config) error {
 
 	type PC struct {
 		StripeSecret string `env:"STRIPE_SECRET" envDefault:"stripe_secret"`
+		RailwayPort  string `env:"PORT" envDefault:"3000"`
 		Flags        FlagsService
 	}
 	p := PC{}
@@ -35,6 +36,7 @@ func (pc ProjectConfig) Build(cfg *ConfigBuilder.Config) error {
 		cfg.ProjectProperties = make(map[string]interface{})
 	}
 	cfg.ProjectProperties["stripeKey"] = p.StripeSecret
+	cfg.ProjectProperties["railway_port"] = p.RailwayPort
 
 	cfg.ProjectProperties["flags_agent"] = p.Flags.AgentID
 	cfg.ProjectProperties["flags_environment"] = p.Flags.EnvironmentID

--- a/internal/project/http.go
+++ b/internal/project/http.go
@@ -121,7 +121,7 @@ func (s *System) CreateProject(w http.ResponseWriter, r *http.Request) {
 	clerk.SetKey(s.Config.Clerk.Key)
 	usr, err := clerkUser.Get(s.Context, r.Header.Get("x-user-subject"))
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(http.StatusUnauthorized)
 		return
 	}
 

--- a/internal/service.go
+++ b/internal/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/flags-gg/orchestrator/internal/secretmenu"
 	ConfigBuilder "github.com/keloran/go-config"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/bugfixes/go-bugfixes/logs"
@@ -149,9 +150,19 @@ func (s *Service) startHTTP(errChan chan error) {
 		mw.AddAllowedOrigins("http://localhost:3000", "http://localhost:5173", "*")
 	}
 
+	port := s.Config.Local.HTTPPort
+	if s.Config.ProjectProperties["railway_port"].(string) != "" {
+		i, err := strconv.Atoi(s.Config.ProjectProperties["railway_port"].(string))
+		if err != nil {
+			_ = logs.Errorf("Failed to parse port: %v", err)
+			return
+		}
+		port = i
+	}
+
 	logs.Logf("Starting HTTP on %d", s.Config.Local.HTTPPort)
 	server := &http.Server{
-		Addr:              fmt.Sprintf(":%d", s.Config.Local.HTTPPort),
+		Addr:              fmt.Sprintf(":%d", port),
 		Handler:           mw.Handler(mux),
 		ReadTimeout:       10 * time.Second,
 		WriteTimeout:      10 * time.Second,


### PR DESCRIPTION
Changes the project creation error response from 500 Internal Server
Error to 401 Unauthorized when the user cannot be retrieved from Clerk.
This ensures the correct HTTP status code is returned when the user is
not authorized to perform the action.