### PR TITLE
feat(agent): remove agent error and success tracking

### DIFF
--- a/cmd/orchestrator/service.go
+++ b/cmd/orchestrator/service.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/bugfixes/go-bugfixes/logs"
-	env "github.com/caarlos0/env/v8"
+	"github.com/caarlos0/env/v8"
 	"github.com/flags-gg/orchestrator/internal"
 	ConfigBuilder "github.com/keloran/go-config"
 )

--- a/internal/flags/agent.go
+++ b/internal/flags/agent.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"errors"
-	"github.com/flags-gg/orchestrator/internal/stats"
 	"github.com/jackc/pgx/v5"
 	"math/big"
 	"strings"
@@ -18,15 +17,15 @@ func (s *System) GetAgentFlagsFromDB(projectId, agentId, environmentId string) (
 
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
-		stats.NewSystem(s.Config).AddAgentError(projectId, agentId, environmentId)
-		if strings.Contains(err.Error(), "operation was canceled") {
-			return nil, nil
-		}
+		//stats.NewSystem(s.Config).AddAgentError(projectId, agentId, environmentId)
+		//if strings.Contains(err.Error(), "operation was canceled") {
+		//	return nil, nil
+		//}
 		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {
 		if err := client.Close(s.Context); err != nil {
-			stats.NewSystem(s.Config).AddAgentError(projectId, agentId, environmentId)
+			//stats.NewSystem(s.Config).AddAgentError(projectId, agentId, environmentId)
 			s.Config.Bugfixes.Logger.Fatalf("Failed to close database connection: %v", err)
 		}
 	}()
@@ -82,7 +81,7 @@ func (s *System) GetAgentFlagsFromDB(projectId, agentId, environmentId string) (
 			return nil, nil
 		}
 
-		stats.NewSystem(s.Config).AddAgentError(projectId, agentId, environmentId)
+		//stats.NewSystem(s.Config).AddAgentError(projectId, agentId, environmentId)
 		if err.Error() == "context canceled" || errors.Is(err, context.Canceled) {
 			return nil, nil
 		}
@@ -180,7 +179,7 @@ func (s *System) GetAgentFlagsFromDB(projectId, agentId, environmentId string) (
 
 	}
 
-	stats.NewSystem(s.Config).AddAgentSuccess(projectId, agentId, environmentId)
+	//stats.NewSystem(s.Config).AddAgentSuccess(projectId, agentId, environmentId)
 	return res, nil
 }
 

--- a/internal/flags/http.go
+++ b/internal/flags/http.go
@@ -6,7 +6,6 @@ import (
 	"github.com/clerk/clerk-sdk-go/v2"
 	clerkUser "github.com/clerk/clerk-sdk-go/v2/user"
 	"github.com/flags-gg/orchestrator/internal/company"
-	"github.com/flags-gg/orchestrator/internal/stats"
 	ConfigBuilder "github.com/keloran/go-config"
 	"net/http"
 	"strconv"
@@ -89,10 +88,10 @@ func (s *System) GetAgentFlags(w http.ResponseWriter, r *http.Request) {
 
 	if err := json.NewEncoder(w).Encode(responseObj); err != nil {
 		_, _ = w.Write([]byte(`{"error": "failed to encode response"}`))
-		stats.NewSystem(s.Config).AddAgentError(projectId, agentId, environmentId)
+		//stats.NewSystem(s.Config).AddAgentError(projectId, agentId, environmentId)
 		_ = s.Config.Bugfixes.Logger.Errorf("Failed to encode response: %v", err)
 	}
-	stats.NewSystem(s.Config).AddAgentSuccess(projectId, agentId, environmentId)
+	//stats.NewSystem(s.Config).AddAgentSuccess(projectId, agentId, environmentId)
 }
 
 func (s *System) GetClientFlags(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
The changes remove the calls to `AddAgentError` and `AddAgentSuccess` functions from the `internal/flags/agent.go` file. This is done to remove the dependency on the `internal/stats` package, which is not being used in the current context. The changes focus on simplifying the code and reducing unnecessary dependencies.