### PR TITLE
feat: Add new API endpoint for agent flags

### DIFF
--- a/internal/service.go
+++ b/internal/service.go
@@ -74,6 +74,7 @@ func (s *Service) startHTTP(errChan chan error) {
 	mux.HandleFunc("GET /environments", environment.NewSystem(s.Config).GetEnvironments)
 
 	// Flags
+	mux.HandleFunc("GET /v1/flags", flags.NewSystem(s.Config).GetAgentFlags)                           // temp whilst apis update
 	mux.HandleFunc("GET /flags", flags.NewSystem(s.Config).GetAgentFlags)                              // used by the library
 	mux.HandleFunc("GET /environment/{environmentId}/flags", flags.NewSystem(s.Config).GetClientFlags) // used by the frontend
 	mux.HandleFunc("POST /flag", flags.NewSystem(s.Config).CreateFlags)


### PR DESCRIPTION
Adds a new API endpoint at `/v1/flags` to retrieve the agent flags. This
is a temporary endpoint while the APIs are being updated, and will be
used by the agent to fetch the flags. The existing `/flags` endpoint
will continue to be used by the library, and the
`/environment/{environmentId}/flags` endpoint will be used by the
frontend.