### PR TITLE
feat(agent): add handling for canceled database operations

### DIFF
--- a/internal/flags/agent.go
+++ b/internal/flags/agent.go
@@ -18,9 +18,9 @@ func (s *System) GetAgentFlagsFromDB(projectId, agentId, environmentId string) (
 	client, err := s.Config.Database.GetPGXClient(s.Context)
 	if err != nil {
 		//stats.NewSystem(s.Config).AddAgentError(projectId, agentId, environmentId)
-		//if strings.Contains(err.Error(), "operation was canceled") {
-		//	return nil, nil
-		//}
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil, nil
+		}
 		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
 	}
 	defer func() {


### PR DESCRIPTION
Adds a check for the "operation was canceled" error when connecting to the
database in the GetAgentFlagsFromDB function. This ensures that the function
returns a nil error instead of propagating the canceled operation error, which
can occur during database connection failures.