### PR TITLE
feat(orchestrator): Add support for Railway deployment

### DIFF
--- a/cmd/orchestrator/service.go
+++ b/cmd/orchestrator/service.go
@@ -25,6 +25,7 @@ func (pc ProjectConfig) Build(cfg *ConfigBuilder.Config) error {
 	type PC struct {
 		StripeSecret string `env:"STRIPE_SECRET" envDefault:"stripe_secret"`
 		RailwayPort  string `env:"PORT" envDefault:"3000"`
+		OnRailway    bool   `env:"ON_RAILWAY" envDefault:"false"`
 		Flags        FlagsService
 	}
 	p := PC{}
@@ -37,6 +38,7 @@ func (pc ProjectConfig) Build(cfg *ConfigBuilder.Config) error {
 	}
 	cfg.ProjectProperties["stripeKey"] = p.StripeSecret
 	cfg.ProjectProperties["railway_port"] = p.RailwayPort
+	cfg.ProjectProperties["on_railway"] = p.OnRailway
 
 	cfg.ProjectProperties["flags_agent"] = p.Flags.AgentID
 	cfg.ProjectProperties["flags_environment"] = p.Flags.EnvironmentID

--- a/internal/service.go
+++ b/internal/service.go
@@ -152,7 +152,7 @@ func (s *Service) startHTTP(errChan chan error) {
 	}
 
 	port := s.Config.Local.HTTPPort
-	if s.Config.ProjectProperties["railway_port"].(string) != "" {
+	if s.Config.ProjectProperties["railway_port"].(string) != "" && s.Config.ProjectProperties["on_railway"].(bool) {
 		i, err := strconv.Atoi(s.Config.ProjectProperties["railway_port"].(string))
 		if err != nil {
 			_ = logs.Errorf("Failed to parse port: %v", err)
@@ -166,7 +166,7 @@ func (s *Service) startHTTP(errChan chan error) {
 		Addr:              fmt.Sprintf(":%d", port),
 		Handler:           mw.Handler(mux),
 		ReadTimeout:       10 * time.Second,
-		WriteTimeout:      10 * time.Second,
+		WriteTimeout:      30 * time.Second,
 		IdleTimeout:       10 * time.Second,
 		ReadHeaderTimeout: 10 * time.Second,
 		TLSNextProto:      make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0),


### PR DESCRIPTION
Adds a new configuration property `on_railway` to the project configuration
to indicate if the service is running on Railway. This is used to determine
the correct port to listen on when running on Railway.

Also increases the `WriteTimeout` for the HTTP server to 30 seconds to
accommodate longer-running requests.