### PR TITLE
feat(webhooks): Add new Stripe webhook endpoint

### DIFF
--- a/internal/service.go
+++ b/internal/service.go
@@ -129,6 +129,7 @@ func (s *Service) startHTTP(errChan chan error) {
 
 	// General Webhooks
 	mux.HandleFunc("/webhooks/stripe", general.NewSystem(s.Config).StripeEvents)
+	mux.HandleFunc("/v1/webhooks/stripe", general.NewSystem(s.Config).StripeEvents)
 
 	// middlewares
 	mw := middleware.NewMiddleware(context.Background())


### PR DESCRIPTION
Adds a new `/v1/webhooks/stripe` endpoint to handle Stripe webhook
events. This is in addition to the existing `/webhooks/stripe`
endpoint, and provides a versioned API for future expansion.