### PR TITLE
feat(user): handle nil company name in onboarding

### DIFF
--- a/internal/user/postgres.go
+++ b/internal/user/postgres.go
@@ -92,7 +92,8 @@ func (s *System) RetrieveUserDetailsDB(subject string) (*User, error) {
 		}
 	}()
 
-	companyName := ""
+	cName := ""
+	companyName := &cName
 
 	user := &User{}
 	ug := &Group{}
@@ -128,7 +129,7 @@ func (s *System) RetrieveUserDetailsDB(subject string) (*User, error) {
 	}
 	user.UserGroup = ug
 
-	if companyName != "" && user.Onboarded == false {
+	if companyName != nil && user.Onboarded == false {
 		user.Onboarded = true
 
 		if _, err := client.Exec(s.Context, `


### PR DESCRIPTION
When retrieving user details from the database, the changes ensure that
the company name is properly handled when the value is nil. This
prevents errors when updating the user's onboarding status.