### PR TITLE
feat: add org request and API key audit stats

### DIFF
--- a/internal/dashboard/http.go
+++ b/internal/dashboard/http.go
@@ -1,0 +1,215 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/flags-gg/orchestrator/internal/agent"
+	"github.com/flags-gg/orchestrator/internal/company"
+	"github.com/flags-gg/orchestrator/internal/environment"
+	"github.com/flags-gg/orchestrator/internal/flags"
+	"github.com/flags-gg/orchestrator/internal/project"
+	"github.com/flags-gg/orchestrator/internal/stats"
+	ConfigBuilder "github.com/keloran/go-config"
+)
+
+type System struct {
+	Config *ConfigBuilder.Config
+}
+
+func NewSystem(cfg *ConfigBuilder.Config) *System {
+	return &System{Config: cfg}
+}
+
+type EnvironmentCoverage struct {
+	Id            string `json:"id"`
+	Name          string `json:"name"`
+	EnvironmentId string `json:"environment_id"`
+	AgentId       string `json:"agent_id"`
+	AgentName     string `json:"agent_name,omitempty"`
+	ProjectName   string `json:"project_name,omitempty"`
+	TotalFlags    int    `json:"totalFlags"`
+	EnabledFlags  int    `json:"enabledFlags"`
+}
+
+type Summary struct {
+	Projects            []project.Project          `json:"projects"`
+	Agents              []*agent.Agent             `json:"agents"`
+	Environments        []*environment.Environment `json:"environments"`
+	AllFlags            []flags.CompanyFlagEntry   `json:"allFlags"`
+	NewestProject       *project.Project           `json:"newestProject,omitempty"`
+	NewestFlag          *flags.CompanyFlagEntry    `json:"newestFlag,omitempty"`
+	RecentFlagChanges   []flags.CompanyFlagEntry   `json:"recentFlagChanges"`
+	EnvironmentCoverage []EnvironmentCoverage      `json:"environmentCoverage"`
+	Stats               stats.CompanyOverview      `json:"stats"`
+}
+
+func parseTimestamp(value string) int64 {
+	if value == "" {
+		return 0
+	}
+
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err == nil {
+		return parsed.Unix()
+	}
+
+	parsed, err = time.Parse(time.RFC3339, value)
+	if err == nil {
+		return parsed.Unix()
+	}
+
+	return 0
+}
+
+func (s *System) GetSummary(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	w.Header().Set("x-flags-timestamp", strconv.FormatInt(time.Now().Unix(), 10))
+	w.Header().Set("Content-Type", "application/json")
+
+	userSubject := r.Header.Get("x-user-subject")
+	if userSubject == "" {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	companyId, err := company.NewSystem(s.Config).GetCompanyId(ctx, userSubject)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if companyId == "" {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	projects, err := project.NewSystem(s.Config).GetProjectsFromDB(ctx, companyId)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	agents, err := agent.NewSystem(s.Config).GetAgents(ctx, companyId)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	environments, err := environment.NewSystem(s.Config).GetEnvironmentsFromDB(ctx, companyId)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	allFlags, err := flags.NewSystem(s.Config).GetCompanyFlagsFromDB(ctx, companyId)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	overview, err := stats.NewSystem(s.Config).GetCompanyOverview(ctx, companyId)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if overview == nil {
+		overview = &stats.CompanyOverview{}
+	}
+
+	coverageMap := make(map[string]*EnvironmentCoverage, len(environments))
+	for _, env := range environments {
+		coverageMap[env.EnvironmentId] = &EnvironmentCoverage{
+			Id:            env.Id,
+			Name:          env.Name,
+			EnvironmentId: env.EnvironmentId,
+			AgentId:       env.AgentId,
+			AgentName:     env.AgentName,
+			ProjectName:   env.ProjectName,
+		}
+	}
+
+	for _, entry := range allFlags {
+		coverage, ok := coverageMap[entry.Environment.EnvironmentId]
+		if !ok {
+			coverage = &EnvironmentCoverage{
+				Id:            entry.Environment.Id,
+				Name:          entry.Environment.Name,
+				EnvironmentId: entry.Environment.EnvironmentId,
+				AgentId:       entry.Environment.AgentId,
+				AgentName:     entry.Environment.AgentName,
+				ProjectName:   entry.Environment.ProjectName,
+			}
+			coverageMap[entry.Environment.EnvironmentId] = coverage
+		}
+
+		coverage.TotalFlags++
+		if entry.Flag.Enabled {
+			coverage.EnabledFlags++
+		}
+	}
+
+	coverage := make([]EnvironmentCoverage, 0, len(coverageMap))
+	for _, item := range coverageMap {
+		coverage = append(coverage, *item)
+	}
+	sort.Slice(coverage, func(i, j int) bool {
+		if coverage[i].TotalFlags == coverage[j].TotalFlags {
+			return coverage[i].EnvironmentId < coverage[j].EnvironmentId
+		}
+		return coverage[i].TotalFlags > coverage[j].TotalFlags
+	})
+	if len(coverage) > 6 {
+		coverage = coverage[:6]
+	}
+
+	sort.Slice(projects, func(i, j int) bool {
+		return projects[i].ID > projects[j].ID
+	})
+
+	newestProject := (*project.Project)(nil)
+	if len(projects) > 0 {
+		newestProject = &projects[0]
+	}
+
+	allFlagsSorted := append([]flags.CompanyFlagEntry(nil), allFlags...)
+	sort.Slice(allFlagsSorted, func(i, j int) bool {
+		return allFlagsSorted[i].Flag.Details.ID > allFlagsSorted[j].Flag.Details.ID
+	})
+
+	newestFlag := (*flags.CompanyFlagEntry)(nil)
+	if len(allFlagsSorted) > 0 {
+		newestFlag = &allFlagsSorted[0]
+	}
+
+	recentFlagChanges := make([]flags.CompanyFlagEntry, 0, len(allFlags))
+	for _, entry := range allFlags {
+		if parseTimestamp(entry.Flag.Details.LastChanged) > 0 {
+			recentFlagChanges = append(recentFlagChanges, entry)
+		}
+	}
+	sort.Slice(recentFlagChanges, func(i, j int) bool {
+		return parseTimestamp(recentFlagChanges[i].Flag.Details.LastChanged) > parseTimestamp(recentFlagChanges[j].Flag.Details.LastChanged)
+	})
+	if len(recentFlagChanges) > 5 {
+		recentFlagChanges = recentFlagChanges[:5]
+	}
+
+	response := Summary{
+		Projects:            projects,
+		Agents:              agents,
+		Environments:        environments,
+		AllFlags:            allFlags,
+		NewestProject:       newestProject,
+		NewestFlag:          newestFlag,
+		RecentFlagChanges:   recentFlagChanges,
+		EnvironmentCoverage: coverage,
+		Stats:               *overview,
+	}
+
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}

--- a/internal/flags/apikey_http.go
+++ b/internal/flags/apikey_http.go
@@ -7,6 +7,7 @@ import (
 	"github.com/clerk/clerk-sdk-go/v2"
 	clerkUser "github.com/clerk/clerk-sdk-go/v2/user"
 	"github.com/flags-gg/orchestrator/internal/company"
+	"github.com/flags-gg/orchestrator/internal/stats"
 	ConfigBuilder "github.com/keloran/go-config"
 )
 
@@ -101,6 +102,10 @@ func (s *APIKeyHTTPSystem) GenerateAPIKeyHandler(w http.ResponseWriter, r *http.
 			"error": "Failed to generate API key",
 		})
 		return
+	}
+
+	if err := stats.NewSystem(s.Config).RecordAPIKeyCreation(ctx, userId, req.ProjectID, req.AgentID, req.EnvironmentID); err != nil {
+		_ = s.Config.Bugfixes.Logger.Errorf("Failed to record api key creation: %v", err)
 	}
 
 	// Return response

--- a/internal/flags/apikey_test.go
+++ b/internal/flags/apikey_test.go
@@ -3,6 +3,7 @@ package flags
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -215,4 +216,114 @@ func TestOFREPFallbackToIndividualHeaders(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "feature-flag-1", response.Key)
 	assert.NotNil(t, response.Value)
+}
+
+func TestOFREPRequestAuditIsRecorded(t *testing.T) {
+	ctx := context.Background()
+
+	testDB, err := setupTestDatabase(ctx)
+	if err != nil {
+		t.Fatalf("Failed to setup test database: %v", err)
+	}
+	defer func() {
+		if err := testDB.container.Terminate(ctx); err != nil {
+			t.Errorf("Failed to terminate container: %v", err)
+		}
+	}()
+
+	_, ofrepSystem := setupTestSystem(t)
+
+	singleBody, _ := json.Marshal(EvaluationRequest{})
+	singleReq := httptest.NewRequest(http.MethodPost, "/ofrep/v1/evaluate/flags/feature-flag-1", bytes.NewReader(singleBody))
+	singleReq.Header.Set("x-project-id", "test-project-1")
+	singleReq.Header.Set("x-agent-id", "test-agent-1")
+	singleReq.Header.Set("x-environment-id", "test-env-1")
+	singleReq.SetPathValue("key", "feature-flag-1")
+
+	singleW := httptest.NewRecorder()
+	ofrepSystem.EvaluateSingleFlag(singleW, singleReq)
+	assert.Equal(t, http.StatusOK, singleW.Code)
+
+	bulkBody, _ := json.Marshal(BulkEvaluationRequest{})
+	bulkReq := httptest.NewRequest(http.MethodPost, "/ofrep/v1/evaluate/flags", bytes.NewReader(bulkBody))
+	bulkReq.Header.Set("x-project-id", "test-project-1")
+	bulkReq.Header.Set("x-agent-id", "test-agent-1")
+	bulkReq.Header.Set("x-environment-id", "test-env-1")
+
+	bulkW := httptest.NewRecorder()
+	ofrepSystem.EvaluateBulkFlags(bulkW, bulkReq)
+	assert.Equal(t, http.StatusOK, bulkW.Code)
+
+	db, err := sql.Open("postgres", testDB.uri)
+	assert.NoError(t, err)
+	defer func() {
+		_ = db.Close()
+	}()
+
+	var singleCount int
+	err = db.QueryRow(`
+		SELECT COUNT(*)
+		FROM public.environment_request_audit
+		WHERE request_kind = 'single_flag'
+		  AND request_source = 'ofrep_single'
+		  AND environment_id = 'test-env-1'`).Scan(&singleCount)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, singleCount)
+
+	var allCount int
+	err = db.QueryRow(`
+		SELECT COUNT(*)
+		FROM public.environment_request_audit
+		WHERE request_kind = 'all_flags'
+		  AND request_source = 'ofrep_bulk'
+		  AND environment_id = 'test-env-1'`).Scan(&allCount)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, allCount)
+}
+
+func TestAPIKeyCreationAuditIsRecorded(t *testing.T) {
+	ctx := context.Background()
+
+	testDB, err := setupTestDatabase(ctx)
+	if err != nil {
+		t.Fatalf("Failed to setup test database: %v", err)
+	}
+	defer func() {
+		if err := testDB.container.Terminate(ctx); err != nil {
+			t.Errorf("Failed to terminate container: %v", err)
+		}
+	}()
+
+	system, _ := setupTestSystem(t)
+	httpSystem := NewAPIKeyHTTPSystem(system.Config)
+
+	body, _ := json.Marshal(GenerateAPIKeyRequest{
+		ProjectID:     "test-project-1",
+		AgentID:       "test-agent-1",
+		EnvironmentID: "test-env-1",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api-key/generate", bytes.NewReader(body))
+	req.Header.Set("x-user-subject", "ignored-in-dev-mode")
+	w := httptest.NewRecorder()
+
+	httpSystem.GenerateAPIKeyHandler(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	db, err := sql.Open("postgres", testDB.uri)
+	assert.NoError(t, err)
+	defer func() {
+		_ = db.Close()
+	}()
+
+	var count int
+	err = db.QueryRow(`
+		SELECT COUNT(*)
+		FROM public.api_key_audit
+		WHERE project_id = 'test-project-1'
+		  AND agent_id = 'test-agent-1'
+		  AND environment_id = 'test-env-1'
+		  AND created_by_subject = 'test-user-subject'`).Scan(&count)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, count)
 }

--- a/internal/flags/client.go
+++ b/internal/flags/client.go
@@ -13,6 +13,20 @@ type flagCreate struct {
 	AgentId       string `json:"agentId"`
 }
 
+type CompanyFlagEnvironment struct {
+	Id            string `json:"id"`
+	Name          string `json:"name"`
+	EnvironmentId string `json:"environment_id"`
+	AgentId       string `json:"agent_id"`
+	AgentName     string `json:"agent_name,omitempty"`
+	ProjectName   string `json:"project_name,omitempty"`
+}
+
+type CompanyFlagEntry struct {
+	Flag        Flag                   `json:"flag"`
+	Environment CompanyFlagEnvironment `json:"environment"`
+}
+
 func (s *System) GetClientFlagsFromDB(ctx context.Context, environmentId string) ([]Flag, error) {
 	client, err := s.Config.Database.GetPGXClient(ctx)
 	if err != nil {
@@ -69,6 +83,81 @@ func (s *System) GetClientFlagsFromDB(ctx context.Context, environmentId string)
 	}
 
 	return flags, nil
+}
+
+func (s *System) GetCompanyFlagsFromDB(ctx context.Context, companyId string) ([]CompanyFlagEntry, error) {
+	client, err := s.Config.Database.GetPGXClient(ctx)
+	if err != nil {
+		return nil, s.Config.Bugfixes.Logger.Errorf("failed to connect to database: %v", err)
+	}
+	defer func() {
+		if err := client.Close(ctx); err != nil {
+			_ = s.Config.Bugfixes.Logger.Errorf("failed to close database connection: %v", err)
+		}
+	}()
+
+	rows, err := client.Query(ctx, `
+		SELECT
+			f.id,
+			f.name,
+			f.enabled,
+			COALESCE(f.updated_at::text, ''),
+			COALESCE(
+				EXISTS (
+					SELECT 1
+					FROM public.environment_chain ec
+					JOIN public.flag f2 ON f2.agent_id = f.agent_id
+						AND f2.name = f.name
+						AND f2.environment_id = ec.child_environment_id
+					WHERE ec.agent_id = f.agent_id
+						AND ec.parent_environment_id = f.environment_id
+				), false
+			) AS promoted,
+			env.id,
+			env.name,
+			env.env_id,
+			agent.agent_id,
+			COALESCE(agent.name, ''),
+			COALESCE(project.name, '')
+		FROM public.flag f
+			JOIN public.environment env ON env.id = f.environment_id
+			JOIN public.agent agent ON agent.id = f.agent_id
+			JOIN public.project project ON project.id = agent.project_id
+			JOIN public.company company ON company.id = project.company_id
+		WHERE company.company_id = $1`, companyId)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return []CompanyFlagEntry{}, nil
+		}
+		return nil, s.Config.Bugfixes.Logger.Errorf("failed to get company flags: %v", err)
+	}
+	defer rows.Close()
+	if rows.Err() != nil {
+		return nil, s.Config.Bugfixes.Logger.Errorf("failed to get company flags: %v", err)
+	}
+
+	entries := make([]CompanyFlagEntry, 0)
+	for rows.Next() {
+		entry := CompanyFlagEntry{}
+		if err := rows.Scan(
+			&entry.Flag.Details.ID,
+			&entry.Flag.Details.Name,
+			&entry.Flag.Enabled,
+			&entry.Flag.Details.LastChanged,
+			&entry.Flag.Details.Promoted,
+			&entry.Environment.Id,
+			&entry.Environment.Name,
+			&entry.Environment.EnvironmentId,
+			&entry.Environment.AgentId,
+			&entry.Environment.AgentName,
+			&entry.Environment.ProjectName,
+		); err != nil {
+			return nil, s.Config.Bugfixes.Logger.Errorf("failed to scan row: %v", err)
+		}
+		entries = append(entries, entry)
+	}
+
+	return entries, nil
 }
 
 func (s *System) UpdateFlagInDB(ctx context.Context, flag Flag) error {

--- a/internal/flags/http.go
+++ b/internal/flags/http.go
@@ -10,6 +10,7 @@ import (
 	"github.com/clerk/clerk-sdk-go/v2"
 	clerkUser "github.com/clerk/clerk-sdk-go/v2/user"
 	"github.com/flags-gg/orchestrator/internal/company"
+	"github.com/flags-gg/orchestrator/internal/stats"
 	ConfigBuilder "github.com/keloran/go-config"
 )
 
@@ -87,6 +88,15 @@ func (s *System) GetAgentFlags(w http.ResponseWriter, r *http.Request) {
 	projectId := r.Header.Get("x-project-id")
 	agentId := r.Header.Get("x-agent-id")
 	environmentId := r.Header.Get("x-environment-id")
+	if environmentId == "" {
+		resolvedEnvironmentId, err := s.GetDefaultEnvironment(ctx, projectId, agentId)
+		if err != nil {
+			_ = s.Config.Bugfixes.Logger.Errorf("Failed to resolve environment: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		environmentId = resolvedEnvironmentId
+	}
 
 	res, err := s.GetAgentFlagsFromDB(ctx, projectId, agentId, environmentId)
 	if err != nil {
@@ -105,7 +115,16 @@ func (s *System) GetAgentFlags(w http.ResponseWriter, r *http.Request) {
 		//stats.NewSystem(s.Config).AddAgentError(projectId, agentId, environmentId)
 		_ = s.Config.Bugfixes.Logger.Errorf("Failed to encode response: %v", err)
 	}
-	//stats.NewSystem(s.Config).AddAgentSuccess(projectId, agentId, environmentId)
+	if err := stats.NewSystem(s.Config).RecordEnvironmentRequest(
+		ctx,
+		projectId,
+		agentId,
+		environmentId,
+		stats.RequestKindAllFlags,
+		stats.RequestSourceSDKAll,
+	); err != nil {
+		_ = s.Config.Bugfixes.Logger.Errorf("Failed to record sdk flag request: %v", err)
+	}
 }
 
 func (s *System) GetClientFlags(w http.ResponseWriter, r *http.Request) {

--- a/internal/flags/ofrep_http.go
+++ b/internal/flags/ofrep_http.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/flags-gg/orchestrator/internal/stats"
 	ConfigBuilder "github.com/keloran/go-config"
 )
 
@@ -133,6 +134,14 @@ func (s *OFREPSystem) EvaluateSingleFlag(w http.ResponseWriter, r *http.Request)
 		s.sendErrorResponse(w, flagKey, ErrorInvalidContext, "Missing project-id or agent-id headers", http.StatusBadRequest)
 		return
 	}
+	if environmentId == "" {
+		defaultEnvironmentId, err := NewSystem(s.Config).GetDefaultEnvironment(ctx, projectId, agentId)
+		if err != nil {
+			s.sendErrorResponse(w, flagKey, ErrorGeneral, "Failed to resolve environment", http.StatusInternalServerError)
+			return
+		}
+		environmentId = defaultEnvironmentId
+	}
 
 	flag, err := s.GetSingleFlagFromDB(ctx, projectId, agentId, environmentId, flagKey)
 	if err != nil {
@@ -143,6 +152,17 @@ func (s *OFREPSystem) EvaluateSingleFlag(w http.ResponseWriter, r *http.Request)
 	if flag == nil {
 		s.sendErrorResponse(w, flagKey, ErrorFlagNotFound, "Flag not found", http.StatusNotFound)
 		return
+	}
+
+	if err := stats.NewSystem(s.Config).RecordEnvironmentRequest(
+		ctx,
+		projectId,
+		agentId,
+		environmentId,
+		stats.RequestKindSingleFlag,
+		stats.RequestSourceOFREPSingle,
+	); err != nil {
+		_ = s.Config.Bugfixes.Logger.Errorf("Failed to record single flag request: %v", err)
 	}
 
 	response := SuccessEvaluationResponse{
@@ -190,6 +210,17 @@ func (s *OFREPSystem) EvaluateBulkFlags(w http.ResponseWriter, r *http.Request) 
 		})
 		return
 	}
+	if environmentId == "" {
+		defaultEnvironmentId, err := NewSystem(s.Config).GetDefaultEnvironment(ctx, projectId, agentId)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(BulkEvaluationResponse{
+				Flags: []interface{}{},
+			})
+			return
+		}
+		environmentId = defaultEnvironmentId
+	}
 
 	flags, err := NewSystem(s.Config).GetAgentFlagsFromDB(ctx, projectId, agentId, environmentId)
 	if err != nil {
@@ -198,6 +229,17 @@ func (s *OFREPSystem) EvaluateBulkFlags(w http.ResponseWriter, r *http.Request) 
 			Flags: []interface{}{},
 		})
 		return
+	}
+
+	if err := stats.NewSystem(s.Config).RecordEnvironmentRequest(
+		ctx,
+		projectId,
+		agentId,
+		environmentId,
+		stats.RequestKindAllFlags,
+		stats.RequestSourceOFREPBulk,
+	); err != nil {
+		_ = s.Config.Bugfixes.Logger.Errorf("Failed to record bulk flag request: %v", err)
 	}
 
 	var responses []interface{}

--- a/internal/flags/ofrep_test.go
+++ b/internal/flags/ofrep_test.go
@@ -80,8 +80,33 @@ func setupTestDatabase(c context.Context) (*testContainer, error) {
 
 	// Create schema
 	_, err = db.Exec(`
+		CREATE TABLE public.company (
+			id serial PRIMARY KEY,
+			company_id varchar(255) NOT NULL,
+			name varchar(255) NOT NULL,
+			created_at timestamp NOT NULL DEFAULT now()
+		);
+
+		CREATE TABLE public."user" (
+			id serial PRIMARY KEY,
+			subject varchar(255) NOT NULL,
+			email_address varchar(255),
+			first_name varchar(255),
+			last_name varchar(255),
+			known_as varchar(255),
+			created_at timestamp NOT NULL DEFAULT now()
+		);
+
+		CREATE TABLE public.company_user (
+			id serial PRIMARY KEY,
+			company_id integer REFERENCES public.company(id),
+			user_id integer REFERENCES public."user"(id),
+			created_at timestamp NOT NULL DEFAULT now()
+		);
+
 		CREATE TABLE public.project (
 			id serial PRIMARY KEY,
+			company_id integer REFERENCES public.company(id),
 			project_id varchar(255) NOT NULL,
 			name varchar(255) NOT NULL,
 			enabled boolean NOT NULL DEFAULT true,
@@ -138,6 +163,25 @@ func setupTestDatabase(c context.Context) (*testContainer, error) {
 			header text,
 			created_at timestamp NOT NULL DEFAULT now()
 		);
+
+		CREATE TABLE public.environment_request_audit (
+			id serial PRIMARY KEY,
+			project_id varchar(255) NOT NULL,
+			agent_id varchar(255) NOT NULL,
+			environment_id varchar(255) NOT NULL,
+			request_kind varchar(32) NOT NULL,
+			request_source varchar(32) NOT NULL,
+			created_at timestamp NOT NULL DEFAULT now()
+		);
+
+		CREATE TABLE public.api_key_audit (
+			id serial PRIMARY KEY,
+			project_id varchar(255) NOT NULL,
+			agent_id varchar(255) NOT NULL,
+			environment_id varchar(255),
+			created_by_subject varchar(255) NOT NULL,
+			created_at timestamp NOT NULL DEFAULT now()
+		);
 	`)
 	if err != nil {
 		return nil, err
@@ -145,8 +189,17 @@ func setupTestDatabase(c context.Context) (*testContainer, error) {
 
 	// Insert test data
 	_, err = db.Exec(`
-		INSERT INTO public.project (project_id, name, enabled)
-		VALUES ('test-project-1', 'Test Project', true);
+		INSERT INTO public.company (company_id, name)
+		VALUES ('test-company-1', 'Test Company');
+
+		INSERT INTO public."user" (subject, email_address, first_name, last_name, known_as)
+		VALUES ('test-user-subject', 'test@example.com', 'Test', 'User', 'Tester');
+
+		INSERT INTO public.company_user (company_id, user_id)
+		VALUES (1, 1);
+
+		INSERT INTO public.project (company_id, project_id, name, enabled)
+		VALUES (1, 'test-project-1', 'Test Project', true);
 
 		INSERT INTO public.agent (agent_id, project_id, name, enabled, interval)
 		VALUES ('test-agent-1', 1, 'Test Agent', true, 60);
@@ -175,6 +228,8 @@ func setupTestSystem(t *testing.T) (*System, *OFREPSystem) {
 	if err := c.Build(ConfigBuilder.Database, ConfigBuilder.Bugfixes); err != nil {
 		t.Fatalf("Failed to build config: %v", err)
 	}
+	c.Local.Development = true
+	c.Clerk.DevUser = "test-user-subject"
 
 	return NewSystem(c), NewOFREPSystem(c)
 }

--- a/internal/service.go
+++ b/internal/service.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/flags-gg/orchestrator/internal/agent"
+	"github.com/flags-gg/orchestrator/internal/dashboard"
 	"github.com/flags-gg/orchestrator/internal/environment"
 	"github.com/flags-gg/orchestrator/internal/general"
 	"github.com/flags-gg/orchestrator/internal/pricing"
@@ -99,6 +100,7 @@ func (s *Service) startHTTP(errChan chan error) {
 	mux.HandleFunc("GET /secret-menu/{menuId}/style", secretmenu.NewSystem(s.Config).GetSecretMenuStyle)
 
 	// Stats
+	mux.HandleFunc("GET /stats/dashboard", dashboard.NewSystem(s.Config).GetSummary)
 	mux.HandleFunc("GET /stats/company", stats.NewSystem(s.Config).GetCompanyStats)
 	mux.HandleFunc("GET /stats/agent/{agentId}/environment/{environmentId}", stats.NewSystem(s.Config).GetEnvironmentStats)
 	mux.HandleFunc("GET /stats/project/{projectId}", stats.NewSystem(s.Config).GetProjectStats)

--- a/internal/stats/audit_postgres.go
+++ b/internal/stats/audit_postgres.go
@@ -1,0 +1,251 @@
+package stats
+
+import (
+	"context"
+	"strings"
+)
+
+type RequestKind string
+
+const (
+	RequestKindSingleFlag RequestKind = "single_flag"
+	RequestKindAllFlags   RequestKind = "all_flags"
+)
+
+type RequestSource string
+
+const (
+	RequestSourceOFREPSingle RequestSource = "ofrep_single"
+	RequestSourceOFREPBulk   RequestSource = "ofrep_bulk"
+	RequestSourceSDKAll      RequestSource = "sdk_all"
+)
+
+type EnvironmentRequestSummary struct {
+	EnvironmentID      string `json:"environment_id"`
+	EnvironmentName    string `json:"environment_name"`
+	AgentID            string `json:"agent_id"`
+	AgentName          string `json:"agent_name"`
+	ProjectID          string `json:"project_id"`
+	ProjectName        string `json:"project_name"`
+	SingleFlagRequests int    `json:"single_flag_requests"`
+	AllFlagsRequests   int    `json:"all_flags_requests"`
+	TotalRequests      int    `json:"total_requests"`
+}
+
+type RequestTotals struct {
+	SingleFlagRequests int `json:"single_flag_requests"`
+	AllFlagsRequests   int `json:"all_flags_requests"`
+	TotalRequests      int `json:"total_requests"`
+}
+
+type APIKeyCreator struct {
+	Subject         string `json:"subject"`
+	Name            string `json:"name"`
+	Email           string `json:"email"`
+	CreatedAt       string `json:"created_at"`
+	ProjectID       string `json:"project_id"`
+	ProjectName     string `json:"project_name"`
+	AgentID         string `json:"agent_id"`
+	AgentName       string `json:"agent_name"`
+	EnvironmentID   string `json:"environment_id,omitempty"`
+	EnvironmentName string `json:"environment_name,omitempty"`
+}
+
+type CompanyOverview struct {
+	RequestTotals       RequestTotals               `json:"request_totals"`
+	EnvironmentRequests []EnvironmentRequestSummary `json:"environment_requests"`
+	LatestAPIKeyCreator *APIKeyCreator              `json:"latest_api_key_creator,omitempty"`
+}
+
+func (s *System) RecordEnvironmentRequest(ctx context.Context, projectId, agentId, environmentId string, requestKind RequestKind, requestSource RequestSource) error {
+	if projectId == "" || agentId == "" || environmentId == "" {
+		return nil
+	}
+
+	client, err := s.Config.Database.GetPGXClient(ctx)
+	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil
+		}
+		return s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
+	}
+	defer func() {
+		if err := client.Close(ctx); err != nil {
+			_ = s.Config.Bugfixes.Logger.Errorf("Failed to close database connection: %v", err)
+		}
+	}()
+
+	if _, err := client.Exec(ctx, `
+		INSERT INTO public.environment_request_audit (
+			project_id,
+			agent_id,
+			environment_id,
+			request_kind,
+			request_source
+		) VALUES ($1, $2, $3, $4, $5)`,
+		projectId,
+		agentId,
+		environmentId,
+		requestKind,
+		requestSource,
+	); err != nil {
+		return s.Config.Bugfixes.Logger.Errorf("Failed to insert environment request audit: %v", err)
+	}
+
+	return nil
+}
+
+func (s *System) RecordAPIKeyCreation(ctx context.Context, userSubject, projectId, agentId, environmentId string) error {
+	if userSubject == "" || projectId == "" || agentId == "" {
+		return nil
+	}
+
+	client, err := s.Config.Database.GetPGXClient(ctx)
+	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil
+		}
+		return s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
+	}
+	defer func() {
+		if err := client.Close(ctx); err != nil {
+			_ = s.Config.Bugfixes.Logger.Errorf("Failed to close database connection: %v", err)
+		}
+	}()
+
+	if _, err := client.Exec(ctx, `
+		INSERT INTO public.api_key_audit (
+			project_id,
+			agent_id,
+			environment_id,
+			created_by_subject
+		) VALUES ($1, $2, NULLIF($3, ''), $4)`,
+		projectId,
+		agentId,
+		environmentId,
+		userSubject,
+	); err != nil {
+		return s.Config.Bugfixes.Logger.Errorf("Failed to insert api key audit: %v", err)
+	}
+
+	return nil
+}
+
+func (s *System) GetCompanyOverview(ctx context.Context, companyId string) (*CompanyOverview, error) {
+	client, err := s.Config.Database.GetPGXClient(ctx)
+	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil, nil
+		}
+		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to connect to database: %v", err)
+	}
+	defer func() {
+		if err := client.Close(ctx); err != nil {
+			_ = s.Config.Bugfixes.Logger.Errorf("Failed to close database connection: %v", err)
+		}
+	}()
+
+	overview := &CompanyOverview{
+		EnvironmentRequests: make([]EnvironmentRequestSummary, 0),
+	}
+
+	rows, err := client.Query(ctx, `
+		SELECT
+			era.environment_id,
+			COALESCE(env.name, ''),
+			era.agent_id,
+			COALESCE(agent.name, ''),
+			era.project_id,
+			COALESCE(project.name, ''),
+			COUNT(*) FILTER (WHERE era.request_kind = 'single_flag')::int AS single_flag_requests,
+			COUNT(*) FILTER (WHERE era.request_kind = 'all_flags')::int AS all_flags_requests,
+			COUNT(*)::int AS total_requests
+		FROM public.environment_request_audit era
+			JOIN public.project project ON project.project_id = era.project_id
+			JOIN public.company company ON company.id = project.company_id
+			LEFT JOIN public.agent agent ON agent.agent_id = era.agent_id
+			LEFT JOIN public.environment env ON env.env_id = era.environment_id
+		WHERE company.company_id = $1
+		GROUP BY
+			era.environment_id,
+			env.name,
+			era.agent_id,
+			agent.name,
+			era.project_id,
+			project.name
+		ORDER BY total_requests DESC, project.name ASC, agent.name ASC, env.name ASC`, companyId)
+	if err != nil {
+		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to query environment request audit: %v", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		summary := EnvironmentRequestSummary{}
+		if err := rows.Scan(
+			&summary.EnvironmentID,
+			&summary.EnvironmentName,
+			&summary.AgentID,
+			&summary.AgentName,
+			&summary.ProjectID,
+			&summary.ProjectName,
+			&summary.SingleFlagRequests,
+			&summary.AllFlagsRequests,
+			&summary.TotalRequests,
+		); err != nil {
+			return nil, s.Config.Bugfixes.Logger.Errorf("Failed to scan environment request audit row: %v", err)
+		}
+
+		overview.RequestTotals.SingleFlagRequests += summary.SingleFlagRequests
+		overview.RequestTotals.AllFlagsRequests += summary.AllFlagsRequests
+		overview.RequestTotals.TotalRequests += summary.TotalRequests
+		overview.EnvironmentRequests = append(overview.EnvironmentRequests, summary)
+	}
+
+	if rows.Err() != nil {
+		return nil, s.Config.Bugfixes.Logger.Errorf("Failed to iterate environment request audit rows: %v", rows.Err())
+	}
+
+	creator := &APIKeyCreator{}
+	err = client.QueryRow(ctx, `
+		SELECT
+			aka.created_by_subject,
+			COALESCE(
+				NULLIF(u.known_as, ''),
+				NULLIF(TRIM(COALESCE(u.first_name, '') || ' ' || COALESCE(u.last_name, '')), ''),
+				NULLIF(u.email_address, ''),
+				aka.created_by_subject
+			) AS display_name,
+			COALESCE(u.email_address, ''),
+			aka.created_at::text,
+			aka.project_id,
+			COALESCE(project.name, ''),
+			aka.agent_id,
+			COALESCE(agent.name, ''),
+			COALESCE(aka.environment_id, ''),
+			COALESCE(env.name, '')
+		FROM public.api_key_audit aka
+			JOIN public.project project ON project.project_id = aka.project_id
+			JOIN public.company company ON company.id = project.company_id
+			LEFT JOIN public.agent agent ON agent.agent_id = aka.agent_id
+			LEFT JOIN public.environment env ON env.env_id = aka.environment_id
+			LEFT JOIN public.user u ON u.subject = aka.created_by_subject
+		WHERE company.company_id = $1
+		ORDER BY aka.created_at DESC
+		LIMIT 1`, companyId).Scan(
+		&creator.Subject,
+		&creator.Name,
+		&creator.Email,
+		&creator.CreatedAt,
+		&creator.ProjectID,
+		&creator.ProjectName,
+		&creator.AgentID,
+		&creator.AgentName,
+		&creator.EnvironmentID,
+		&creator.EnvironmentName,
+	)
+	if err == nil {
+		overview.LatestAPIKeyCreator = creator
+	}
+
+	return overview, nil
+}

--- a/internal/stats/http.go
+++ b/internal/stats/http.go
@@ -3,7 +3,12 @@ package stats
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
+	"time"
 
+	"github.com/clerk/clerk-sdk-go/v2"
+	clerkUser "github.com/clerk/clerk-sdk-go/v2/user"
+	"github.com/flags-gg/orchestrator/internal/company"
 	ConfigBuilder "github.com/keloran/go-config"
 )
 
@@ -17,10 +22,59 @@ func NewSystem(cfg *ConfigBuilder.Config) *System {
 	}
 }
 
-func (s *System) GetCompanyStats(w http.ResponseWriter, r *http.Request) {
-	_ = r
+func (s *System) getUserId(r *http.Request) (string, error) {
+	if s.Config.Local.Development && s.Config.Clerk.DevUser != "" {
+		return s.Config.Clerk.DevUser, nil
+	}
 
-	w.WriteHeader(http.StatusNotImplemented)
+	clerk.SetKey(s.Config.Clerk.Key)
+	usr, err := clerkUser.Get(r.Context(), r.Header.Get("x-user-subject"))
+	if err != nil {
+		return "", err
+	}
+
+	return usr.ID, nil
+}
+
+func (s *System) GetCompanyStats(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	w.Header().Set("x-flags-timestamp", strconv.FormatInt(time.Now().Unix(), 10))
+	w.Header().Set("Content-Type", "application/json")
+
+	if r.Header.Get("x-user-subject") == "" {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	userId, err := s.getUserId(r)
+	if err != nil {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	companyId, err := company.NewSystem(s.Config).GetCompanyId(ctx, userId)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if companyId == "" {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	overview, err := s.GetCompanyOverview(ctx, companyId)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if overview == nil {
+		overview = &CompanyOverview{}
+	}
+
+	if err := json.NewEncoder(w).Encode(overview); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
 }
 
 func (s *System) GetProjectStats(w http.ResponseWriter, r *http.Request) {

--- a/k8s/schema/0003_request_and_api_key_audit.down.sql
+++ b/k8s/schema/0003_request_and_api_key_audit.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS public.api_key_audit;
+DROP TABLE IF EXISTS public.environment_request_audit;

--- a/k8s/schema/0003_request_and_api_key_audit.up.sql
+++ b/k8s/schema/0003_request_and_api_key_audit.up.sql
@@ -1,0 +1,33 @@
+CREATE TABLE public.environment_request_audit (
+    id serial PRIMARY KEY,
+    created_at timestamp without time zone NOT NULL DEFAULT now(),
+    project_id character varying(255) NOT NULL,
+    agent_id character varying(255) NOT NULL,
+    environment_id character varying(255) NOT NULL,
+    request_kind character varying(32) NOT NULL,
+    request_source character varying(32) NOT NULL
+);
+
+CREATE INDEX environment_request_audit_project_idx
+    ON public.environment_request_audit (project_id);
+
+CREATE INDEX environment_request_audit_environment_idx
+    ON public.environment_request_audit (environment_id);
+
+CREATE INDEX environment_request_audit_kind_idx
+    ON public.environment_request_audit (request_kind);
+
+CREATE TABLE public.api_key_audit (
+    id serial PRIMARY KEY,
+    created_at timestamp without time zone NOT NULL DEFAULT now(),
+    project_id character varying(255) NOT NULL,
+    agent_id character varying(255) NOT NULL,
+    environment_id character varying(255) NULL,
+    created_by_subject character varying(255) NOT NULL
+);
+
+CREATE INDEX api_key_audit_project_idx
+    ON public.api_key_audit (project_id);
+
+CREATE INDEX api_key_audit_created_by_idx
+    ON public.api_key_audit (created_by_subject);


### PR DESCRIPTION
## Summary
- add Postgres audit tables for environment request telemetry and API key creation
- record exact request kind by endpoint: OFREP single flag, OFREP bulk, and flags.gg SDK all-flags fetches
- expose org-level stats from `GET /stats/company`, including latest SDK key creator

## Details
This adds:
- `environment_request_audit`
- `api_key_audit`

Recorded semantics:
- `POST /ofrep/v1/evaluate/flags/{key}` -> `single_flag`
- `POST /ofrep/v1/evaluate/flags` -> `all_flags`
- `GET /flags` and `GET /v1/flags` -> `all_flags`

It also resolves the effective default environment before logging, so counts land against the actual environment used.

## Why
Dashboard needs org-scoped analytics for:
- how often environments are requested
- split between single-flag and all-flags requests
- latest person to create an SDK key

## Testing
- `go test ./internal/flags/...`
- `go test ./internal/stats/...`
